### PR TITLE
docs: add headless operation research and deployment guide

### DIFF
--- a/docs/operations/headless-mac-deployment.md
+++ b/docs/operations/headless-mac-deployment.md
@@ -1,0 +1,123 @@
+# BlueBubbles Server: Headless Mac Deployment Guide
+
+## Prerequisites
+
+- macOS 14+ (Sonoma, Sequoia, or Tahoe)
+- Mac Mini with auto-login configured
+- FileVault DISABLED
+- Network access (SSH + Screen Sharing)
+
+## Setup Checklist
+
+1. Disable FileVault: `sudo fdesetup disable`
+2. Enable auto-login: System Settings > Users & Groups > Automatic Login
+3. Disable sleep: `sudo pmset -a sleep 0 displaysleep 0 disksleep 0`
+4. Install BetterDummy or HDMI dummy plug for virtual display
+5. Enable Screen Sharing: System Settings > General > Sharing > Screen Sharing
+6. Enable SSH: System Settings > General > Sharing > Remote Login
+7. Install BlueBubbles Server (from source or DMG)
+
+## LaunchAgent Setup
+
+Create `~/Library/LaunchAgents/com.bluebubbles.server.plist`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.bluebubbles.server</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/Applications/BlueBubbles.app/Contents/MacOS/BlueBubbles</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <dict>
+        <key>SuccessfulExit</key>
+        <false/>
+    </dict>
+    <key>StandardOutPath</key>
+    <string>/tmp/bluebubbles.stdout.log</string>
+    <key>StandardErrorPath</key>
+    <string>/tmp/bluebubbles.stderr.log</string>
+</dict>
+</plist>
+```
+
+Load with:
+
+```bash
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.bluebubbles.server.plist
+```
+
+## Gotchas & Known Issues
+
+### FileVault + Auto-Login
+
+FileVault MUST be disabled. There is no workaround. FileVault encrypts the boot volume and requires user authentication before the OS fully loads -- auto-login cannot work.
+
+### No True Headless Mode
+
+BlueBubbles CANNOT run as a LaunchDaemon (system-level service). It requires a user GUI session because:
+
+- Electron needs WindowServer for process initialization
+- AppleScript iMessage commands need the Aqua session
+- Messages.app/imagent daemon is user-session bound
+
+See `docs/research/2026-04-14-headless-operation.md` for full architectural analysis.
+
+### Headless Mode + Terminal Startup
+
+Do NOT enable both "Headless mode" and "Always Start via Terminal" simultaneously -- this is a known broken combination (upstream #733). Services fail to initialize. Use one or the other.
+
+### HDMI Dummy / Virtual Display
+
+Without a connected display (or dummy), macOS restricts GPU features and resolution. This can cause:
+
+- Degraded Screen Sharing performance
+- WindowServer issues
+- GPU feature availability problems
+
+Use BetterDummy (software, free, Apple Silicon compatible) or an HDMI dummy plug ($10-15).
+
+### Sleep Prevention
+
+Even with auto-login, macOS may sleep the machine. Use:
+
+```bash
+sudo pmset -a sleep 0 displaysleep 0 disksleep 0
+caffeinate -s &  # belt and suspenders
+```
+
+### Gateway Restart Error Noise
+
+When OpenClaw gateways restart, BlueBubbles generates transient webhook delivery errors. These are noise -- the gateway is temporarily unavailable. See issue for retry/backoff improvement.
+
+### Electron on macOS 26 Tahoe
+
+Electron apps can cause WindowServer GPU overload on Tahoe due to cornerMask API. Ensure Electron is updated (upstream fixes in electron PRs #48376, #48400).
+
+## Remote Management
+
+- **SSH**: `ssh user@hostname` for CLI operations
+- **Screen Sharing**: `vnc://hostname` for GUI access (required for some BB settings)
+- **BB API**: `http://hostname:1234` for direct API access
+
+## Monitoring
+
+Check BB server health:
+
+```bash
+curl http://localhost:1234/api/v1/server/info
+```
+
+Check LaunchAgent status:
+
+```bash
+launchctl print gui/$(id -u)/com.bluebubbles.server
+```
+
+Logs: Check BB's built-in logging or stdout from LaunchAgent at `/tmp/bluebubbles.stdout.log`.

--- a/docs/research/2026-04-14-headless-operation.md
+++ b/docs/research/2026-04-14-headless-operation.md
@@ -1,0 +1,58 @@
+# Running BlueBubbles Server Headless on macOS
+
+## Executive Summary
+
+True headless (LaunchDaemon, no user login) is NOT possible. Three hard blockers:
+
+1. **Electron requires WindowServer** -- even in headless mode, calls CoreGraphics/AppKit. No Xvfb on macOS.
+2. **AppleScript requires Aqua session** -- BB's iMessage sending uses `tell application "Messages"` and `tell application "System Events"`
+3. **Messages.app/imagent is user-session bound** -- even Private API requires Messages.app in a logged-in user context
+
+## Architecture Analysis
+
+- `packages/server/src/server/index.ts` preChecks() line 795 calls `this.window.minimize()` with no null guard -- crashes in headless mode (upstream #789)
+- `packages/server/src/windows/AppWindow.ts` build() skips BrowserWindow when headless config is set, leaving Server().window as null
+- `packages/server/src/server/fileSystem/index.ts` createLaunchAgent() uses `launchctl bootstrap gui/<uid>` -- explicitly targets GUI user session
+- `packages/server/src/server/api/apple/scripts.ts` all iMessage sending uses osascript with `tell application "Messages"` and `tell application "System Events"` -- requires Aqua session
+- `packages/server/src/main.ts` Electron entry point requires app.whenReady() -- needs WindowServer
+
+## Known Issues
+
+- Headless mode + Always Start via Terminal = broken (upstream #733) -- services never initialize
+- start_via_terminal + launchd parent detection creates restart loop
+- Docker/containers not viable -- iMessage requires macOS + Messages.app (upstream #762)
+- Electron --headless flag suppresses window but does NOT bypass WindowServer
+- LSUIElement already used by BB in headless mode (no Dock icon)
+- Service manager PR #707 attempted proper dependency management -- closed, never merged
+- Electron Tahoe GPU overload fix needed (electron PRs #48376, #48399, #48400)
+
+## What Actually Works
+
+The proven pattern (confirmed by Apple DTS engineers, BB community, and openclaw-infra deployment):
+
+1. Disable FileVault (non-negotiable for auto-login)
+2. Enable auto-login for target user account
+3. LaunchAgent at ~/Library/LaunchAgents/ (NOT LaunchDaemon)
+4. `sudo pmset -a sleep 0` to prevent all sleep
+5. Software virtual display (BetterDummy) or HDMI dummy plug -- prevents GPU/WindowServer degradation
+6. Screen Sharing enabled for remote management
+7. SSH for command-line management (but cannot replace the GUI session)
+
+## Why LaunchDaemon Cannot Work
+
+- LaunchDaemon runs at system boot, root-level, ZERO WindowServer access
+- LaunchAgent runs after user login, HAS GUI access
+- Electron's native code calls CoreGraphics/AppKit at startup regardless of headless flag
+- AppleScript targeting GUI apps doesn't work from non-GUI context
+- Apple DTS engineer quote: "There is no solution that'll work with FileVault"
+
+## Sources
+
+- BlueBubbles autostart docs: https://docs.bluebubbles.app/server/basic-guides/autostart-server-after-crash
+- Upstream issue #789: headless null window crash
+- Upstream issue #733: headless + terminal startup broken
+- Upstream issue #762: Docker/container request (not viable)
+- Apple Developer Forums thread 737381: headless Mac server constraints
+- Electron issue #29164: headless without Xvfb
+- The Eclectic Light Company: LaunchDaemon vs LaunchAgent guide
+- BetterDummy: https://github.com/ZhipingYang/BetterDummy

--- a/docs/research/2026-04-14-private-api-tahoe.md
+++ b/docs/research/2026-04-14-private-api-tahoe.md
@@ -1,0 +1,112 @@
+# Private API on macOS 26 Tahoe: Research & Path Forward
+
+**Date:** 2026-04-14
+**Status:** Active research
+**Related issue:** #16
+
+## Executive Summary
+
+Five separate things broke on macOS 26 Tahoe, not just the dylib injection:
+
+| Layer                             | What Broke                                                     | Severity                       | Fixable?                                |
+| --------------------------------- | -------------------------------------------------------------- | ------------------------------ | --------------------------------------- |
+| DYLIB injection into Messages.app | Launch Constraints enforce trust cache at kernel level         | Fatal                          | No bypass known                         |
+| XPC to imagent directly           | Apple-private entitlements required; third-party rejected      | Fatal for typing/read receipts | No bypass known                         |
+| AppleScript send                  | Chat GUIDs changed from `iMessage;-;` to `any;-;`; error -1700 | Blocking sends                 | **Yes — one-line mapping fix**          |
+| chat.db reads                     | `text` column is NULL; content only in `attributedBody`        | Blocking message detection     | **Yes — column change**                 |
+| LaunchAgent FDA                   | Node processes don't inherit Full Disk Access                  | Blocking chat.db access        | **Workaround: launch via Terminal.app** |
+
+## What Can Be Fixed Now
+
+### 1. AppleScript GUID Mapping (upstream #777)
+
+macOS 26 changed chat GUIDs in the Messages database from `iMessage;-;phone` to `any;-;phone`. The AppleScript dictionary only accepts `iMessage`, `SMS`, or `RCS` as service constants — `any` causes error -1700.
+
+**Fix:** Map `any` → `iMessage` in the `buildServiceScript` function before constructing the AppleScript command. One-line change.
+
+### 2. chat.db attributedBody Column
+
+The `text` column in the Messages database is now always NULL on Tahoe. Actual message content is only in `attributedBody` (NSAttributedString binary blob).
+
+**Fix:** Update database queries to read from `attributedBody` and decode the NSAttributedString. The `universalText()` method on the Message entity already has fallback logic — verify it handles this case.
+
+### 3. Full Disk Access Propagation
+
+Node processes launched via LaunchAgent or Login Item don't inherit FDA on Tahoe. chat.db reads fail silently.
+
+**Workaround:** Launch the process through Terminal.app (which has FDA), so child processes inherit it. Use `tmux new-session` for persistence.
+
+**Long-term fix:** A properly signed native .app wrapper that macOS grants FDA to directly.
+
+## What Cannot Be Fixed (Architectural Blockers)
+
+### DYLIB Injection — Launch Constraints
+
+Launch Constraints work via a trust cache at `/System/Library/Security/OSLaunchPolicyData`. Enforcement is at spawn time — AMFI evaluates whether launch conditions match a binary's constraint category before allowing execution.
+
+- Operates independently of SIP — SIP disabled is necessary but NOT sufficient on Tahoe
+- Trust cache is cryptographically sealed
+- Three constraint types: Self, Parent, Responsible
+- Volume constraints prevent copy-and-run exploitation
+
+**Source:** theevilbit blog deep dive on Launch Constraints
+
+### imagent XPC Entitlement Wall
+
+`com.apple.imagent.desktop.auth` now requires Apple-private entitlements. Any third-party process is rejected with "Client does not have any of the allowed entitlements."
+
+- Not a code signing issue — the entitlements themselves are Apple-restricted
+- IMCore classes still load, selectors present — wall is purely XPC-level
+- `connectToDaemon` and `connectToDaemonWithLaunch:capabilities:` both fail
+
+**Source:** steipete/imsg issue #60
+
+### Protocol Reimplementation (pypush/Beeper) — Dead End
+
+pypush reimplemented iMessage over APNs + IDS in Python. Beeper Mini used this but Apple repeatedly blocked server-side authentication. Beeper Mini shut down 2024, matrix bridge archived April 2025.
+
+Not viable for production — Apple detects and bans unauthorized clients.
+
+## Alternative Approaches (Research Needed)
+
+### Accessibility API for Typing Indicators (Most Promising)
+
+Proposed in steipete/imsg #60: Use `AXUIElement` to programmatically focus the Messages.app text input field. When focused, Messages.app natively sends the typing indicator over iMessage.
+
+- No injection required
+- No entitlements needed (just Accessibility permission)
+- Unverified on Tahoe but architecturally sound
+- Only solves typing indicators, not read receipts
+
+### Messages.app Extension (Uncertain)
+
+If BB shipped a Messages extension loaded by Messages.app itself, it would inherit the app's entitlements. Apple's extension model is limited (iMessage App Extensions / Sticker packs), and likely blocked for IMCore access.
+
+### AMFI Boot Arg (`amfi_get_out_of_my_way`)
+
+Disables AMFI completely at boot. Requires SIP off + NVRAM write. Security nuclear option — only for owned hardware, not end-user installs.
+
+## Community Status
+
+- **BlueBubbles upstream:** Issue #776 (DYLIB failure) and #777 (AppleScript GUID) open, no developer response
+- **steipete/imsg:** Removed typing command as non-functional on Tahoe. Proposed Accessibility API approach.
+- **Beeper/pypush:** Archived/dead
+- **Apple:** WWDC 2024/2025 announced zero public APIs for third-party iMessage integration
+
+## Recommended Action Plan
+
+1. **Immediate:** Fix AppleScript GUID mapping (`any` → `iMessage`) — restores message sending
+2. **Immediate:** Fix chat.db reads to use `attributedBody` — restores message detection
+3. **Short-term:** Implement Accessibility API typing indicator prototype
+4. **Track:** Monitor upstream BlueBubbles for any Tahoe Private API progress
+5. **Accept:** Read receipts via Private API are not achievable on Tahoe without Apple changing their entitlement policy
+
+## Sources
+
+- BlueBubblesApp/bluebubbles-server#776 — DYLIB injection failure on Tahoe
+- BlueBubblesApp/bluebubbles-server#777 — AppleScript GUID error -1700
+- steipete/imsg#60 — imagent entitlement wall, Accessibility API proposal
+- theevilbit blog — Launch Constraints deep dive
+- openclaw/openclaw#5116 — FDA propagation failure
+- openclaw/openclaw#29389 — Private API send regression
+- anthropics/claude-code#41783 — chat.db text column NULL


### PR DESCRIPTION
Captures comprehensive research on headless BB server operation and provides an operations runbook for Mac Mini deployment.

## Files Added

- `docs/research/2026-04-14-headless-operation.md` - Research document covering architectural constraints, known issues, and why true headless is not possible
- `docs/operations/headless-mac-deployment.md` - Operations runbook for deploying BB server on a headless Mac Mini