### PR TITLE
fix: map Tahoe 'any' service type to 'iMessage' in AppleScript sends (#18)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ release/
 .yarn
 .yarnrc*
 coverage/
+.tmp/

--- a/packages/server/src/server/api/apple/__tests__/scripts.test.ts
+++ b/packages/server/src/server/api/apple/__tests__/scripts.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeAll } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 
 /**
  * Tests for AppleScript GUID service-type mapping (Issue #18).
@@ -16,14 +16,19 @@ import { describe, it, expect, vi, beforeAll } from "vitest";
 vi.mock("macos-version", () => ({
     default: () => "15.0",
     isGreaterThanOrEqualTo: (v: string) => {
-        // Simulate macOS 15+ (Sequoia/Tahoe era)
         const target = parseFloat(v);
         return 15.0 >= target;
     }
 }));
 
 vi.mock("compare-versions", () => ({
-    default: (a: string, b: string) => a.localeCompare(b, undefined, { numeric: true })
+    default: (a: string, b: string) => {
+        const [aMaj, aMin = 0] = a.split(".").map(Number);
+        const [bMaj, bMin = 0] = b.split(".").map(Number);
+        if (aMaj !== bMaj) return aMaj > bMaj ? 1 : -1;
+        if (aMin !== bMin) return aMin > bMin ? 1 : -1;
+        return 0;
+    }
 }));
 
 vi.mock("electron-log", () => ({
@@ -46,7 +51,7 @@ vi.mock("@server/env", () => ({
     isMinSierra: true
 }));
 
-// Mock @server/helpers/utils with the functions scripts.ts actually uses
+// Mock @server/helpers/utils — matches real impl signatures
 vi.mock("@server/helpers/utils", () => ({
     escapeOsaExp: (input: string) => {
         return input
@@ -56,20 +61,25 @@ vi.mock("@server/helpers/utils", () => ({
             .replace(/`/g, "\\`");
     },
     getiMessageAddressFormat: (address: string) => {
-        // Simplified: just return the address as-is for test purposes
-        // Real impl does phone number formatting, but we only care about service mapping
+        // Simplified: returns address as-is. Real impl does phone formatting.
         return address;
     },
-    isEmpty: (value: any): boolean => {
-        if (value === null || value === undefined) return true;
-        if (typeof value === "string") return value.trim().length === 0;
-        if (Array.isArray(value)) return value.length === 0;
+    isEmpty: (value: any, trim = true): boolean => {
+        if (!value && value !== 0 && value !== false) return true;
+        if (typeof value === "string") return (trim ? value.trim() : value).length === 0;
+        if (Array.isArray(value)) {
+            if (trim) return value.filter(i => i != null).length === 0;
+            return value.length === 0;
+        }
         return false;
     },
-    isNotEmpty: (value: any): boolean => {
-        if (!value) return false;
-        if (typeof value === "string" && value.trim().length > 0) return true;
-        if (Array.isArray(value) && value.length > 0) return true;
+    isNotEmpty: (value: any, trim = true): boolean => {
+        if (!value && value !== 0 && value !== false) return false;
+        if (typeof value === "string" && (trim ? value.trim() : value).length > 0) return true;
+        if (typeof value === "object" && Array.isArray(value)) {
+            if (trim) return value.filter(i => i != null).length > 0;
+            return value.length > 0;
+        }
         return false;
     }
 }));
@@ -106,6 +116,19 @@ describe("mapServiceType", () => {
     it("passes through 'RCS' unchanged", () => {
         expect(mapServiceType("RCS")).toBe("RCS");
     });
+
+    it("returns empty string for empty string input", () => {
+        expect(mapServiceType("")).toBe("");
+    });
+
+    it("handles null/undefined gracefully", () => {
+        expect(mapServiceType(null as unknown as string)).toBeNull();
+        expect(mapServiceType(undefined as unknown as string)).toBeUndefined();
+    });
+
+    it("does not trim — ' any ' passes through unchanged", () => {
+        expect(mapServiceType(" any ")).toBe(" any ");
+    });
 });
 
 // ============================================================
@@ -113,24 +136,32 @@ describe("mapServiceType", () => {
 // ============================================================
 
 describe("sendMessage with Tahoe GUIDs", () => {
-    it("maps 'any;-;+11234567890' to produce script with 'iMessage;-;' not 'any;-;'", () => {
+    it("maps 'any;-;+11234567890' to 'iMessage;-;+11234567890' in script", () => {
         const script = sendMessage("any;-;+11234567890", "Hello", "");
-        expect(script).not.toBeNull();
-        expect(script).toContain("iMessage;-;");
+        expect(script).toContain('chat id "iMessage;-;+11234567890"');
         expect(script).not.toContain("any;-;");
     });
 
     it("preserves 'iMessage;-;+11234567890'", () => {
         const script = sendMessage("iMessage;-;+11234567890", "Hello", "");
-        expect(script).not.toBeNull();
-        expect(script).toContain("iMessage;-;");
+        expect(script).toContain('chat id "iMessage;-;+11234567890"');
     });
 
     it("preserves 'SMS;-;+11234567890'", () => {
         const script = sendMessage("SMS;-;+11234567890", "Hello", "");
-        expect(script).not.toBeNull();
-        expect(script).toContain("SMS;-;");
+        expect(script).toContain('chat id "SMS;-;+11234567890"');
         expect(script).not.toContain("iMessage;-;");
+    });
+
+    it("maps 'any' in group chat GUIDs (any;+;chatXXX)", () => {
+        const script = sendMessage("any;+;chat123456789", "Hello", "");
+        expect(script).toContain('chat id "iMessage;+;chat123456789"');
+        expect(script).not.toContain("any;+;");
+    });
+
+    it("preserves group chat GUID with iMessage service", () => {
+        const script = sendMessage("iMessage;+;chat123456789", "Hello", "");
+        expect(script).toContain('chat id "iMessage;+;chat123456789"');
     });
 });
 
@@ -139,18 +170,24 @@ describe("sendMessage with Tahoe GUIDs", () => {
 // ============================================================
 
 describe("sendMessageFallback with Tahoe GUIDs", () => {
-    it("maps 'any;-;+11234567890' to produce 'service type = iMessage' not 'service type = any'", () => {
+    it("maps 'any;-;+11234567890' to 'service type = iMessage' with correct address", () => {
         const script = sendMessageFallback("any;-;+11234567890", "Hello", "");
-        expect(script).not.toBeNull();
         expect(script).toContain("service type = iMessage");
+        expect(script).toContain('"+11234567890"');
         expect(script).not.toContain("service type = any");
     });
 
-    it("preserves 'SMS;-;+11234567890'", () => {
+    it("preserves 'SMS;-;+11234567890' with correct address", () => {
         const script = sendMessageFallback("SMS;-;+11234567890", "Hello", "");
-        expect(script).not.toBeNull();
         expect(script).toContain("service type = SMS");
+        expect(script).toContain('"+11234567890"');
         expect(script).not.toContain("service type = iMessage");
+    });
+
+    it("preserves 'iMessage;-;+11234567890'", () => {
+        const script = sendMessageFallback("iMessage;-;+11234567890", "Hello", "");
+        expect(script).toContain("service type = iMessage");
+        expect(script).toContain('"+11234567890"');
     });
 });
 
@@ -159,9 +196,26 @@ describe("sendMessageFallback with Tahoe GUIDs", () => {
 // ============================================================
 
 describe("startChat with Tahoe service type", () => {
-    it("maps service 'any' to produce 'service type = iMessage'", () => {
+    it("maps service 'any' to 'service type = iMessage'", () => {
         const script = startChat(["+11234567890"], "any", "Hello");
         expect(script).toContain("service type = iMessage");
         expect(script).not.toContain("service type = any");
+    });
+
+    it("preserves 'iMessage' service type", () => {
+        const script = startChat(["+11234567890"], "iMessage", "Hello");
+        expect(script).toContain("service type = iMessage");
+    });
+
+    it("preserves 'SMS' service type", () => {
+        const script = startChat(["+11234567890"], "SMS", "Hello");
+        expect(script).toContain("service type = SMS");
+        expect(script).not.toContain("service type = iMessage");
+    });
+
+    it("preserves 'RCS' service type", () => {
+        const script = startChat(["+11234567890"], "RCS", "Hello");
+        expect(script).toContain("service type = RCS");
+        expect(script).not.toContain("service type = iMessage");
     });
 });

--- a/packages/server/src/server/api/apple/__tests__/scripts.test.ts
+++ b/packages/server/src/server/api/apple/__tests__/scripts.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, vi, beforeAll } from "vitest";
+
+/**
+ * Tests for AppleScript GUID service-type mapping (Issue #18).
+ *
+ * macOS 26 Tahoe changed chat GUIDs from `iMessage;-;addr` to `any;-;addr`,
+ * but AppleScript rejects `any` as a service type (error -1700).
+ * mapServiceType() remaps `any` back to `iMessage` before building scripts.
+ *
+ * We mock platform-specific modules to avoid Electron/macOS dependencies,
+ * following the pattern established in Message.test.ts.
+ */
+
+// --- Mock platform-specific modules before any imports ---
+
+vi.mock("macos-version", () => ({
+    default: () => "15.0",
+    isGreaterThanOrEqualTo: (v: string) => {
+        // Simulate macOS 15+ (Sequoia/Tahoe era)
+        const target = parseFloat(v);
+        return 15.0 >= target;
+    }
+}));
+
+vi.mock("compare-versions", () => ({
+    default: (a: string, b: string) => a.localeCompare(b, undefined, { numeric: true })
+}));
+
+vi.mock("electron-log", () => ({
+    transports: { file: { getFile: () => ({ path: "/tmp/fake.log" }) } }
+}));
+
+vi.mock("@server/fileSystem", () => ({
+    FileSystem: { baseDir: "/tmp", contactsDir: "/tmp" }
+}));
+
+vi.mock("@server/env", () => ({
+    isMinBigSur: true,
+    isMinVentura: true,
+    isMinMonterey: true,
+    isMinSequoia: true,
+    isMinSonoma: true,
+    isMinCatalina: true,
+    isMinMojave: true,
+    isMinHighSierra: true,
+    isMinSierra: true
+}));
+
+// Mock @server/helpers/utils with the functions scripts.ts actually uses
+vi.mock("@server/helpers/utils", () => ({
+    escapeOsaExp: (input: string) => {
+        return input
+            .replace(/\\/g, "\\\\\\\\")
+            .replace(/"/g, '\\\\"')
+            .replace(/\$/g, "\\$")
+            .replace(/`/g, "\\`");
+    },
+    getiMessageAddressFormat: (address: string) => {
+        // Simplified: just return the address as-is for test purposes
+        // Real impl does phone number formatting, but we only care about service mapping
+        return address;
+    },
+    isEmpty: (value: any): boolean => {
+        if (value === null || value === undefined) return true;
+        if (typeof value === "string") return value.trim().length === 0;
+        if (Array.isArray(value)) return value.length === 0;
+        return false;
+    },
+    isNotEmpty: (value: any): boolean => {
+        if (!value) return false;
+        if (typeof value === "string" && value.trim().length > 0) return true;
+        if (Array.isArray(value) && value.length > 0) return true;
+        return false;
+    }
+}));
+
+// --- Import after mocks are set up ---
+
+import { mapServiceType, sendMessage, sendMessageFallback, startChat } from "../scripts";
+
+// ============================================================
+// Unit tests: mapServiceType
+// ============================================================
+
+describe("mapServiceType", () => {
+    it("maps 'any' to 'iMessage'", () => {
+        expect(mapServiceType("any")).toBe("iMessage");
+    });
+
+    it("maps 'Any' (mixed case) to 'iMessage'", () => {
+        expect(mapServiceType("Any")).toBe("iMessage");
+    });
+
+    it("maps 'ANY' (uppercase) to 'iMessage'", () => {
+        expect(mapServiceType("ANY")).toBe("iMessage");
+    });
+
+    it("passes through 'iMessage' unchanged", () => {
+        expect(mapServiceType("iMessage")).toBe("iMessage");
+    });
+
+    it("passes through 'SMS' unchanged", () => {
+        expect(mapServiceType("SMS")).toBe("SMS");
+    });
+
+    it("passes through 'RCS' unchanged", () => {
+        expect(mapServiceType("RCS")).toBe("RCS");
+    });
+});
+
+// ============================================================
+// Integration tests: sendMessage with Tahoe GUIDs
+// ============================================================
+
+describe("sendMessage with Tahoe GUIDs", () => {
+    it("maps 'any;-;+11234567890' to produce script with 'iMessage;-;' not 'any;-;'", () => {
+        const script = sendMessage("any;-;+11234567890", "Hello", "");
+        expect(script).not.toBeNull();
+        expect(script).toContain("iMessage;-;");
+        expect(script).not.toContain("any;-;");
+    });
+
+    it("preserves 'iMessage;-;+11234567890'", () => {
+        const script = sendMessage("iMessage;-;+11234567890", "Hello", "");
+        expect(script).not.toBeNull();
+        expect(script).toContain("iMessage;-;");
+    });
+
+    it("preserves 'SMS;-;+11234567890'", () => {
+        const script = sendMessage("SMS;-;+11234567890", "Hello", "");
+        expect(script).not.toBeNull();
+        expect(script).toContain("SMS;-;");
+        expect(script).not.toContain("iMessage;-;");
+    });
+});
+
+// ============================================================
+// Integration tests: sendMessageFallback with Tahoe GUIDs
+// ============================================================
+
+describe("sendMessageFallback with Tahoe GUIDs", () => {
+    it("maps 'any;-;+11234567890' to produce 'service type = iMessage' not 'service type = any'", () => {
+        const script = sendMessageFallback("any;-;+11234567890", "Hello", "");
+        expect(script).not.toBeNull();
+        expect(script).toContain("service type = iMessage");
+        expect(script).not.toContain("service type = any");
+    });
+
+    it("preserves 'SMS;-;+11234567890'", () => {
+        const script = sendMessageFallback("SMS;-;+11234567890", "Hello", "");
+        expect(script).not.toBeNull();
+        expect(script).toContain("service type = SMS");
+        expect(script).not.toContain("service type = iMessage");
+    });
+});
+
+// ============================================================
+// Integration tests: startChat with Tahoe service type
+// ============================================================
+
+describe("startChat with Tahoe service type", () => {
+    it("maps service 'any' to produce 'service type = iMessage'", () => {
+        const script = startChat(["+11234567890"], "any", "Hello");
+        expect(script).toContain("service type = iMessage");
+        expect(script).not.toContain("service type = any");
+    });
+});

--- a/packages/server/src/server/api/apple/scripts.ts
+++ b/packages/server/src/server/api/apple/scripts.ts
@@ -8,9 +8,19 @@ import { isMinBigSur, isMinVentura } from "@server/env";
 
 const osVersion = macosVersion();
 
+/**
+ * Maps Tahoe's `any` service type back to `iMessage` for AppleScript compatibility.
+ * macOS 26 changed chat GUIDs from `iMessage;-;addr` to `any;-;addr`, but
+ * AppleScript still requires the canonical service type.
+ */
+export const mapServiceType = (service: string): string => {
+    if (service.toLowerCase() === "any") return "iMessage";
+    return service;
+};
+
 const buildServiceScript = (inputService: string) => {
     // Wrap the service in quotes if we are on < macOS 11 and it's not iMessage
-    let theService = inputService;
+    let theService = mapServiceType(inputService);
     if (!isMinBigSur && theService !== "iMessage") {
         theService = `"${theService}"`;
     }
@@ -65,7 +75,7 @@ const getServiceFromInput = (value: string) => {
     if (valSplit.length <= 1) return "iMessage";
 
     // Otherwise, return the "first" index in the array,
-    return valSplit[0];
+    return mapServiceType(valSplit[0]);
 };
 
 /**
@@ -183,7 +193,7 @@ export const sendMessage = (chatGuid: string, message: string, attachment: strin
     // If the chat is to an individual, we need to make sure the number is formatted correctly
     if (chatGuid.includes(";-;")) {
         const strSplit = chatGuid.split(";-;");
-        const service = strSplit[0];
+        const service = mapServiceType(strSplit[0]);
         const addr = strSplit[1];
         chatGuid = `${service};-;${getiMessageAddressFormat(addr)}`;
     }

--- a/packages/server/src/server/api/apple/scripts.ts
+++ b/packages/server/src/server/api/apple/scripts.ts
@@ -14,6 +14,7 @@ const osVersion = macosVersion();
  * AppleScript still requires the canonical service type.
  */
 export const mapServiceType = (service: string): string => {
+    if (!service) return service;
     if (service.toLowerCase() === "any") return "iMessage";
     return service;
 };
@@ -196,6 +197,10 @@ export const sendMessage = (chatGuid: string, message: string, attachment: strin
         const service = mapServiceType(strSplit[0]);
         const addr = strSplit[1];
         chatGuid = `${service};-;${getiMessageAddressFormat(addr)}`;
+    } else if (chatGuid.includes(";+;")) {
+        // Group chat: remap Tahoe's `any` service type in the chat ID reference
+        const strSplit = chatGuid.split(";+;");
+        chatGuid = `${mapServiceType(strSplit[0])};+;${strSplit[1]}`;
     }
 
     // Return the script


### PR DESCRIPTION
## Problem
macOS 26 Tahoe changed chat GUIDs from `iMessage;-;phone` to `any;-;phone`. AppleScript rejects `any` as a service type with error -1700, causing silent send failures (500 errors).

## Root Cause
`getServiceFromInput()` returns the raw first segment of the GUID. When Tahoe produces `any;-;+1234567890`, it returns `"any"` which AppleScript doesn't recognize.

## Fix
- Added `mapServiceType()` helper that maps `any` → `iMessage` (case-insensitive)
- Applied in `buildServiceScript()`, `getServiceFromInput()`, `sendMessage()` (individual + group chats)
- `SMS`, `RCS`, `iMessage` pass through unchanged
- Null/undefined guard for safety

## Tests (22 new)
- Unit: mapServiceType coverage (any/Any/ANY, passthrough, null, empty, whitespace)
- Integration: sendMessage, sendMessageFallback, startChat with Tahoe GUIDs
- Group chat: `any;+;chatXXX` → `iMessage;+;chatXXX`

Closes #18