### PR TITLE
research: Accessibility API typing indicators prototype (#20)

### DIFF
--- a/docs/research/2026-04-14-ax-typing-indicators.md
+++ b/docs/research/2026-04-14-ax-typing-indicators.md
@@ -10,6 +10,14 @@ macOS 26 Tahoe killed Private API typing indicators. The DYLIB injection path us
 
 The hypothesis: the macOS Accessibility API (`AXUIElement`) can interact with Messages.app's compose text field without injection or private entitlements, and setting text in that field may trigger a typing indicator on the remote end.
 
+## Test Environment
+
+- **Machine:** Mac Mini (Apple Silicon)
+- **macOS:** 26.0 Tahoe (beta)
+- **Messages.app:** Built-in (Tahoe release)
+- **Swift:** Xcode toolchain (swift 6.x)
+- **Run context:** Messages.app running in background, conversation selected
+
 ## Prototype Results
 
 ### What Works
@@ -99,9 +107,9 @@ Could use `node-addon-api` to wrap AXUIElement calls directly. Better performanc
 
 ## Limitations
 
-1. **Conversation must be selected.** AX can only interact with the currently-visible compose field. If the user has a different conversation open (or no conversation), the typing indicator would go to the wrong chat or fail. **Mitigation:** Use AppleScript to select the correct conversation first, then AX to set text.
+1. **Conversation must be selected + race condition.** AX can only interact with the currently-visible compose field. If the user has a different conversation open (or no conversation), the typing indicator would go to the wrong chat or fail. **Mitigation:** Use AppleScript to select the correct conversation first, then AX to set text. **Race risk:** If the user switches conversations between the AppleScript selection and the AX SetValue, the typing indicator goes to the wrong recipient. Production code must serialize AX operations and validate the active conversation before each SetValue.
 
-2. **Single compose field.** Messages.app has one compose field at a time. Concurrent typing indicators for multiple conversations are not possible via this approach.
+2. **Single compose field — no concurrency.** Messages.app has one compose field at a time. Concurrent typing indicators for multiple conversations are not possible. The integration layer must serialize requests (queue or mutex) to prevent concurrent calls from racing.
 
 3. **Accessibility permission is manual.** Users must grant Accessibility permission in System Settings. Unlike Full Disk Access (which can be guided), this requires navigating to a specific pane and toggling a switch.
 
@@ -115,6 +123,10 @@ Could use `node-addon-api` to wrap AXUIElement calls directly. Better performanc
 | `prototypes/ax-typing/ax-benchmark.swift` | Performance measurement (find, focus, set, cycle) |
 | `prototypes/ax-typing/node-integration.ts` | Concept sketch for Node.js integration |
 | `docs/research/2026-04-14-ax-typing-indicators.md` | This document |
+
+## Security Considerations
+
+**AX privilege is process-wide.** Once Accessibility permission is granted to a binary, it can query and mutate the AX tree of *any* running application — not just Messages.app. If BlueBubbles is compromised (malicious plugin, RCE), an attacker gains AX access to every GUI app including password managers and banking apps. This is a broader privilege surface than Private API (which was scoped to imagent). Using a separate Swift CLI binary (instead of granting Accessibility to the full Electron process) limits the attack surface to just that binary's capabilities.
 
 ## Next Steps
 

--- a/docs/research/2026-04-14-ax-typing-indicators.md
+++ b/docs/research/2026-04-14-ax-typing-indicators.md
@@ -1,0 +1,125 @@
+# Accessibility API Typing Indicators — Research Results
+
+**Date:** 2026-04-14
+**Issue:** #20
+**Status:** Prototype successful, pending manual verification of typing indicator trigger
+
+## Background
+
+macOS 26 Tahoe killed Private API typing indicators. The DYLIB injection path used to hook into `imagent` is blocked by Launch Constraints (kernel-enforced, no bypass). XPC to `imagent` requires Apple-private entitlements. We need an alternative.
+
+The hypothesis: the macOS Accessibility API (`AXUIElement`) can interact with Messages.app's compose text field without injection or private entitlements, and setting text in that field may trigger a typing indicator on the remote end.
+
+## Prototype Results
+
+### What Works
+
+| Capability | Result | Performance |
+|-----------|--------|-------------|
+| Find compose field by identifier (`messageBodyField`) | 10/10 | avg 12ms |
+| Find compose field by placeholder (`iMessage`) | 10/10 | avg 5.7ms |
+| Focus compose field | 10/10 | avg 0.2ms |
+| Set text in compose field | 10/10 | avg 0.3ms |
+| Full cycle (focus + set + clear) | 10/10 | avg 1.9ms |
+| **Background operation** (Messages.app not foreground) | **YES** | — |
+
+### Key Findings
+
+1. **No foreground requirement.** AX operations work with Messages.app in the background. The window does not need to be visible or active. This is critical for headless/background server operation.
+
+2. **Sub-millisecond individual operations.** Focus and SetValue each take < 1ms. Even the full cycle is under 5ms worst case.
+
+3. **Element discovery is reliable.** The compose field is consistently identifiable via `AXIdentifier = "messageBodyField"` or `AXPlaceholderValue = "iMessage"`. The identifier-based search is slightly slower (12ms avg vs 5.7ms) because it does a deeper tree walk.
+
+4. **Message bubbles are also accessible.** Existing messages appear as `AXTextArea` elements with `id = "CKBalloonTextView"`. This could enable reading message content via AX as a fallback if the `attributedBody` decoder fails.
+
+5. **No injection required.** This uses only public macOS Accessibility APIs. No SIP bypass, no DYLIB injection, no private entitlements.
+
+## What Needs Manual Verification
+
+**The critical unknown: does `AXUIElementSetAttributeValue` on the compose field trigger a typing indicator on the remote end?**
+
+There are two possible outcomes:
+
+### Scenario A: SetValue triggers typing indicator
+This is the ideal case. Messages.app internally fires a typing notification to the remote conversation when text appears in the compose field, regardless of how it got there (keyboard vs AX).
+
+**If true:** We have a complete, injection-free typing indicator solution.
+
+### Scenario B: SetValue does NOT trigger typing indicator
+Messages.app may only trigger typing indicators from keyboard events (HID), not from programmatic text changes. In this case, AX SetValue would silently set text without notifying the remote end.
+
+**If true, fallback approaches:**
+1. **AX keystroke simulation** — Use `AXUIElementPostKeyboardEvent` or CGEvents to simulate actual keystrokes after focusing the field. This is more likely to trigger the typing indicator path.
+2. **AppleScript `keystroke` command** — Use System Events to send keystrokes to the focused field. Less precise but simpler.
+3. **Accept the limitation** — Use AX for sending messages (type + press Enter) but not for standalone typing indicators.
+
+### How to Test
+
+1. Open Messages.app on this Mac
+2. Select a conversation with a second device you control
+3. Run: `swift prototypes/ax-typing/ax-probe.swift --set-text "testing"`
+4. Check the second device — is a typing indicator (three dots) visible?
+5. If no: try keystroke simulation (Phase 2 of this R&D)
+
+## Permissions Required
+
+| Permission | How to Grant | Required By |
+|-----------|-------------|-------------|
+| Accessibility | System Settings > Privacy & Security > Accessibility > add Terminal.app (or Node.js binary) | AXUIElement queries and mutations |
+| Full Disk Access | System Settings > Privacy & Security > Full Disk Access | NOT required for AX (only for chat.db reads) |
+| Automation | System Settings > Privacy & Security > Automation | NOT required (AX is separate from AppleScript automation) |
+
+**Important:** The Accessibility permission must be granted to the specific binary that makes the AX calls. If BlueBubbles runs as an Electron app, the Electron binary needs the permission. If running via Node.js, the Node binary needs it. If using a helper Swift binary, that binary needs it.
+
+**LaunchAgent consideration:** When running as a LaunchAgent, the process inherits the user's accessibility permissions. This should work without additional configuration as long as the binary is in the Accessibility allow-list.
+
+## Integration Architecture
+
+### Recommended: Swift CLI helper
+
+```
+BlueBubbles Server
+    └── typing indicator request
+        └── execFile("ax-typing-cli", ["--start-typing", chatGuid])
+            └── Swift binary:
+                1. AXUIElementCreateApplication(Messages PID)
+                2. Find compose field (by identifier or placeholder)
+                3. AXFocus + AXSetValue
+                4. Return "OK" / "FAIL"
+```
+
+**Why a separate binary?** Node.js native addons for Accessibility are fragile and require native compilation. A precompiled Swift binary is simpler, smaller (~100KB), and can be bundled alongside the server. The `execFile` overhead (~15ms) is negligible compared to the human-perceptible typing indicator.
+
+### Alternative: Node native addon
+
+Could use `node-addon-api` to wrap AXUIElement calls directly. Better performance (no process spawn) but higher maintenance burden and platform compilation complexity.
+
+**Not recommended** for initial implementation — premature optimization.
+
+## Limitations
+
+1. **Conversation must be selected.** AX can only interact with the currently-visible compose field. If the user has a different conversation open (or no conversation), the typing indicator would go to the wrong chat or fail. **Mitigation:** Use AppleScript to select the correct conversation first, then AX to set text.
+
+2. **Single compose field.** Messages.app has one compose field at a time. Concurrent typing indicators for multiple conversations are not possible via this approach.
+
+3. **Accessibility permission is manual.** Users must grant Accessibility permission in System Settings. Unlike Full Disk Access (which can be guided), this requires navigating to a specific pane and toggling a switch.
+
+4. **Apple could change the AX tree.** The element identifier `messageBodyField` is an internal implementation detail. A macOS update could rename or restructure it. The placeholder-based fallback (`iMessage`) is more stable but less specific.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `prototypes/ax-typing/ax-probe.swift` | Interactive AX tree probe and text input tester |
+| `prototypes/ax-typing/ax-benchmark.swift` | Performance measurement (find, focus, set, cycle) |
+| `prototypes/ax-typing/node-integration.ts` | Concept sketch for Node.js integration |
+| `docs/research/2026-04-14-ax-typing-indicators.md` | This document |
+
+## Next Steps
+
+1. **Manual verification** — Test whether SetValue triggers typing indicator (requires second device)
+2. If Scenario B: prototype keystroke simulation via AX or CGEvents
+3. If Scenario A: build the Swift CLI binary with conversation selection support
+4. Integrate into BlueBubbles as a fallback when Private API is unavailable
+5. Add conversation selection (AppleScript `set targetChat` before AX text set)

--- a/prototypes/ax-typing/ax-benchmark.swift
+++ b/prototypes/ax-typing/ax-benchmark.swift
@@ -1,0 +1,167 @@
+#!/usr/bin/env swift
+//
+// ax-benchmark.swift — Performance measurement for AX typing indicator approach
+//
+// Measures:
+//   1. Time to find Messages.app text input via AX tree
+//   2. Time to focus the input
+//   3. Time to set text (simulating typing)
+//   4. Time for a full focus+set+clear cycle
+//   5. Whether Messages.app needs to be foreground
+//
+
+import Cocoa
+import ApplicationServices
+
+func isTrusted() -> Bool {
+    let opts = [kAXTrustedCheckOptionPrompt.takeUnretainedValue(): true] as CFDictionary
+    return AXIsProcessTrustedWithOptions(opts)
+}
+
+func getMessagesApp() -> NSRunningApplication? {
+    return NSWorkspace.shared.runningApplications.first {
+        $0.bundleIdentifier == "com.apple.MobileSMS"
+    }
+}
+
+func getAttribute(_ element: AXUIElement, _ attr: String) -> AnyObject? {
+    var value: AnyObject?
+    let err = AXUIElementCopyAttributeValue(element, attr as CFString, &value)
+    return err == .success ? value : nil
+}
+
+func getChildren(_ element: AXUIElement) -> [AXUIElement] {
+    return getAttribute(element, kAXChildrenAttribute) as? [AXUIElement] ?? []
+}
+
+func getRole(_ element: AXUIElement) -> String? {
+    return getAttribute(element, kAXRoleAttribute) as? String
+}
+
+func getIdentifier(_ element: AXUIElement) -> String? {
+    return getAttribute(element, "AXIdentifier") as? String
+}
+
+func getPlaceholder(_ element: AXUIElement) -> String? {
+    return getAttribute(element, kAXPlaceholderValueAttribute) as? String
+}
+
+// Recursive find by identifier
+func findElement(in element: AXUIElement, id: String, maxDepth: Int = 8, depth: Int = 0) -> AXUIElement? {
+    if getIdentifier(element) == id { return element }
+    if depth >= maxDepth { return nil }
+    for child in getChildren(element) {
+        if let found = findElement(in: child, id: id, maxDepth: maxDepth, depth: depth + 1) {
+            return found
+        }
+    }
+    return nil
+}
+
+// Find by placeholder text (for the compose field)
+func findByPlaceholder(in element: AXUIElement, placeholder: String, maxDepth: Int = 8, depth: Int = 0) -> AXUIElement? {
+    if getPlaceholder(element) == placeholder { return element }
+    if depth >= maxDepth { return nil }
+    for child in getChildren(element) {
+        if let found = findByPlaceholder(in: child, placeholder: placeholder, maxDepth: maxDepth, depth: depth + 1) {
+            return found
+        }
+    }
+    return nil
+}
+
+func measure(_ label: String, iterations: Int = 10, block: () -> Bool) {
+    var times: [Double] = []
+    var successes = 0
+    for _ in 0..<iterations {
+        let start = CFAbsoluteTimeGetCurrent()
+        let ok = block()
+        let elapsed = (CFAbsoluteTimeGetCurrent() - start) * 1000.0
+        times.append(elapsed)
+        if ok { successes += 1 }
+    }
+    let avg = times.reduce(0, +) / Double(times.count)
+    let min = times.min() ?? 0
+    let max = times.max() ?? 0
+    print("  \(label): avg=\(String(format: "%.2f", avg))ms min=\(String(format: "%.2f", min))ms max=\(String(format: "%.2f", max))ms (\(successes)/\(iterations) ok)")
+}
+
+func main() {
+    guard isTrusted() else {
+        print("ERROR: Accessibility permission not granted.")
+        exit(1)
+    }
+
+    guard let app = getMessagesApp() else {
+        print("ERROR: Messages.app not running.")
+        exit(1)
+    }
+
+    let appElement = AXUIElementCreateApplication(app.processIdentifier)
+    print("Messages.app PID: \(app.processIdentifier)")
+    print("Messages.app is active (foreground): \(app.isActive)")
+    print()
+
+    // Benchmark 1: Find the compose field
+    print("--- Benchmark: Find compose field ---")
+    var composeField: AXUIElement?
+
+    measure("Find by id 'messageBodyField'") {
+        composeField = findElement(in: appElement, id: "messageBodyField")
+        return composeField != nil
+    }
+
+    measure("Find by placeholder 'iMessage'") {
+        let found = findByPlaceholder(in: appElement, placeholder: "iMessage")
+        return found != nil
+    }
+
+    guard let field = composeField else {
+        print("\nERROR: Could not find compose field. Is a conversation selected?")
+        exit(1)
+    }
+
+    // Benchmark 2: Focus
+    print("\n--- Benchmark: Focus compose field ---")
+    measure("AXFocus") {
+        let err = AXUIElementSetAttributeValue(field, kAXFocusedAttribute as CFString, true as CFTypeRef)
+        return err == .success
+    }
+
+    // Benchmark 3: Set text
+    print("\n--- Benchmark: Set text ---")
+    measure("SetValue 'typing...'") {
+        let err = AXUIElementSetAttributeValue(field, kAXValueAttribute as CFString, "typing..." as CFTypeRef)
+        return err == .success
+    }
+
+    // Clear
+    AXUIElementSetAttributeValue(field, kAXValueAttribute as CFString, "" as CFTypeRef)
+
+    // Benchmark 4: Full cycle (focus + set + clear)
+    print("\n--- Benchmark: Full typing cycle ---")
+    measure("Focus + Set + Clear") {
+        let e1 = AXUIElementSetAttributeValue(field, kAXFocusedAttribute as CFString, true as CFTypeRef)
+        let e2 = AXUIElementSetAttributeValue(field, kAXValueAttribute as CFString, "..." as CFTypeRef)
+        let e3 = AXUIElementSetAttributeValue(field, kAXValueAttribute as CFString, "" as CFTypeRef)
+        return e1 == .success && e2 == .success && e3 == .success
+    }
+
+    // Benchmark 5: Background test
+    print("\n--- Background operation ---")
+    print("Messages.app foreground: \(app.isActive)")
+    print("Testing AX while Messages is NOT foreground...")
+    print("(If Messages IS foreground, minimize it and re-run to test background mode)")
+
+    // Summary
+    print("\n--- Summary ---")
+    print("Compose field found: YES (id=messageBodyField)")
+    print("Focus works: YES")
+    print("SetValue works: YES")
+    print("Background operation: \(app.isActive ? "NEEDS TESTING (Messages is foreground)" : "WORKS")")
+    print()
+    print("CRITICAL QUESTION: Does SetValue trigger the typing indicator on the remote end?")
+    print("This requires manual verification with a second device.")
+}
+
+main()

--- a/prototypes/ax-typing/ax-benchmark.swift
+++ b/prototypes/ax-typing/ax-benchmark.swift
@@ -153,12 +153,11 @@ func main() {
     print("Testing AX while Messages is NOT foreground...")
     print("(If Messages IS foreground, minimize it and re-run to test background mode)")
 
-    // Summary
+    // Summary (derived from actual benchmark results)
     print("\n--- Summary ---")
-    print("Compose field found: YES (id=messageBodyField)")
-    print("Focus works: YES")
-    print("SetValue works: YES")
+    print("Compose field found: \(composeField != nil ? "YES (id=messageBodyField)" : "NO")")
     print("Background operation: \(app.isActive ? "NEEDS TESTING (Messages is foreground)" : "WORKS")")
+    print("(Focus and SetValue pass/fail counts are shown in benchmark output above)")
     print()
     print("CRITICAL QUESTION: Does SetValue trigger the typing indicator on the remote end?")
     print("This requires manual verification with a second device.")

--- a/prototypes/ax-typing/ax-probe.swift
+++ b/prototypes/ax-typing/ax-probe.swift
@@ -120,23 +120,59 @@ func printNode(_ node: AXNode) {
     if let role = node.role { parts.append("role=\(role)") }
     if let subrole = node.subrole { parts.append("subrole=\(subrole)") }
     if let title = node.title, !title.isEmpty { parts.append("title=\"\(title)\"") }
-    if let desc = node.description, !desc.isEmpty { parts.append("desc=\"\(desc)\"") }
+    if let desc = node.description, !desc.isEmpty {
+        // Redact long descriptions — they contain message content from the transcript
+        if desc.count > 80 {
+            parts.append("desc=<redacted, \(desc.count) chars>")
+        } else {
+            parts.append("desc=\"\(desc)\"")
+        }
+    }
     if let id = node.identifier, !id.isEmpty { parts.append("id=\"\(id)\"") }
     if let ph = node.placeholder, !ph.isEmpty { parts.append("placeholder=\"\(ph)\"") }
     if let val = node.value {
-        let truncated = val.count > 50 ? String(val.prefix(50)) + "..." : val
-        parts.append("value=\"\(truncated)\"")
+        // Redact message bubble content to avoid PII leaks in terminal/logs
+        let isBubble = node.identifier == "CKBalloonTextView"
+        if isBubble {
+            parts.append("value=<redacted, \(val.count) chars>")
+        } else {
+            let truncated = val.count > 50 ? String(val.prefix(50)) + "..." : val
+            parts.append("value=\"\(truncated)\"")
+        }
     }
     print("\(indent)\(parts.joined(separator: " | "))")
 }
 
 // MARK: - Find Text Input
 
+func findComposeField(_ element: AXUIElement) -> AXUIElement? {
+    // Primary: find by identifier (most reliable)
+    if let field = findByIdentifierOrPlaceholder(element, id: "messageBodyField", placeholder: nil) {
+        return field
+    }
+    // Fallback: find by placeholder (iMessage or Text Message)
+    if let field = findByIdentifierOrPlaceholder(element, id: nil, placeholder: "iMessage") {
+        return field
+    }
+    return findByIdentifierOrPlaceholder(element, id: nil, placeholder: "Text Message")
+}
+
+func findByIdentifierOrPlaceholder(_ element: AXUIElement, id: String?, placeholder: String?, depth: Int = 0, maxDepth: Int = 8) -> AXUIElement? {
+    if let id = id, getIdentifier(element) == id { return element }
+    if let ph = placeholder, getPlaceholder(element) == ph { return element }
+    if depth >= maxDepth { return nil }
+    for child in getChildren(element) {
+        if let found = findByIdentifierOrPlaceholder(child, id: id, placeholder: placeholder, depth: depth + 1, maxDepth: maxDepth) {
+            return found
+        }
+    }
+    return nil
+}
+
 func findTextInputs(_ element: AXUIElement) -> [AXUIElement] {
     let nodes = walkTree(element)
     return nodes.compactMap { node in
         guard let role = node.role else { return nil }
-        // Look for text areas, text fields, and web areas that might contain text input
         if role == kAXTextAreaRole as String ||
            role == kAXTextFieldRole as String ||
            (role == "AXWebArea" && node.subrole == nil) {
@@ -209,35 +245,35 @@ func main() {
         print("[\(i)] role=\(role) id=\(identifier) placeholder=\(placeholder) value=\"\(value)\"")
     }
 
-    // Mode: set text
+    // Mode: set text (targets compose field specifically, not message bubbles)
     if let idx = args.firstIndex(of: "--set-text"), idx + 1 < args.count {
         let text = args[idx + 1]
-        guard let firstInput = textInputs.first else {
-            print("\nERROR: No text input found to set text on.")
+        guard let composeField = findComposeField(appElement) else {
+            print("\nERROR: No compose field found. Is a conversation selected?")
             exit(1)
         }
-        print("\nAttempting to set text to: \"\(text)\"")
-        let focused = focusElement(firstInput)
+        print("\nAttempting to set compose field text...")
+        let focused = focusElement(composeField)
         print("  Focus result: \(focused ? "OK" : "FAILED")")
-        let set = setText(firstInput, text: text)
+        let set = setText(composeField, text: text)
         print("  SetValue result: \(set ? "OK" : "FAILED")")
 
         // Re-read value
-        let newValue = getValue(firstInput) ?? "<empty>"
-        print("  Current value: \"\(newValue)\"")
+        let newValue = getValue(composeField) ?? "<empty>"
+        print("  Current value length: \(newValue.count) chars")
 
         print("\n** CHECK: Did the remote recipient see a typing indicator? **")
         return
     }
 
-    // Mode: focus
+    // Mode: focus (targets compose field specifically)
     if args.contains("--focus") {
-        guard let firstInput = textInputs.first else {
-            print("\nERROR: No text input found to focus.")
+        guard let composeField = findComposeField(appElement) else {
+            print("\nERROR: No compose field found. Is a conversation selected?")
             exit(1)
         }
-        print("\nAttempting to focus text input...")
-        let result = focusElement(firstInput)
+        print("\nAttempting to focus compose field...")
+        let result = focusElement(composeField)
         print("  Focus result: \(result ? "OK" : "FAILED")")
 
         print("\n** CHECK: Did the remote recipient see a typing indicator? **")

--- a/prototypes/ax-typing/ax-probe.swift
+++ b/prototypes/ax-typing/ax-probe.swift
@@ -1,0 +1,258 @@
+#!/usr/bin/env swift
+//
+// ax-probe.swift — Accessibility API probe for Messages.app
+//
+// Queries the AX hierarchy of Messages.app to find text input fields.
+// Used to evaluate whether typing indicators can be triggered via AX
+// instead of the Private API (which is dead on Tahoe).
+//
+// Requirements:
+//   - Accessibility permission granted to Terminal.app (or whatever runs this)
+//   - Messages.app must be running
+//
+// Usage:
+//   swift ax-probe.swift [--dump]     Probe Messages.app AX tree
+//   swift ax-probe.swift --set-text "hello"   Set text in the input field
+//   swift ax-probe.swift --focus      Focus the text input field
+//
+
+import Cocoa
+import ApplicationServices
+
+// MARK: - Helpers
+
+func isTrusted() -> Bool {
+    let opts = [kAXTrustedCheckOptionPrompt.takeUnretainedValue(): true] as CFDictionary
+    return AXIsProcessTrustedWithOptions(opts)
+}
+
+func getMessagesApp() -> NSRunningApplication? {
+    return NSWorkspace.shared.runningApplications.first {
+        $0.bundleIdentifier == "com.apple.MobileSMS"
+    }
+}
+
+func axElement(for app: NSRunningApplication) -> AXUIElement {
+    return AXUIElementCreateApplication(app.processIdentifier)
+}
+
+func getAttribute(_ element: AXUIElement, _ attr: String) -> AnyObject? {
+    var value: AnyObject?
+    let err = AXUIElementCopyAttributeValue(element, attr as CFString, &value)
+    return err == .success ? value : nil
+}
+
+func getChildren(_ element: AXUIElement) -> [AXUIElement] {
+    guard let children = getAttribute(element, kAXChildrenAttribute) as? [AXUIElement] else {
+        return []
+    }
+    return children
+}
+
+func getRole(_ element: AXUIElement) -> String? {
+    return getAttribute(element, kAXRoleAttribute) as? String
+}
+
+func getSubrole(_ element: AXUIElement) -> String? {
+    return getAttribute(element, kAXSubroleAttribute) as? String
+}
+
+func getTitle(_ element: AXUIElement) -> String? {
+    return getAttribute(element, kAXTitleAttribute) as? String
+}
+
+func getDescription(_ element: AXUIElement) -> String? {
+    return getAttribute(element, kAXDescriptionAttribute) as? String
+}
+
+func getValue(_ element: AXUIElement) -> String? {
+    return getAttribute(element, kAXValueAttribute) as? String
+}
+
+func getIdentifier(_ element: AXUIElement) -> String? {
+    return getAttribute(element, "AXIdentifier") as? String
+}
+
+func getPlaceholder(_ element: AXUIElement) -> String? {
+    return getAttribute(element, kAXPlaceholderValueAttribute) as? String
+}
+
+// MARK: - Tree Walker
+
+struct AXNode {
+    let element: AXUIElement
+    let role: String?
+    let subrole: String?
+    let title: String?
+    let description: String?
+    let value: String?
+    let identifier: String?
+    let placeholder: String?
+    let depth: Int
+}
+
+func walkTree(_ element: AXUIElement, depth: Int = 0, maxDepth: Int = 8) -> [AXNode] {
+    var nodes: [AXNode] = []
+    let node = AXNode(
+        element: element,
+        role: getRole(element),
+        subrole: getSubrole(element),
+        title: getTitle(element),
+        description: getDescription(element),
+        value: getValue(element),
+        identifier: getIdentifier(element),
+        placeholder: getPlaceholder(element),
+        depth: depth
+    )
+    nodes.append(node)
+
+    if depth < maxDepth {
+        for child in getChildren(element) {
+            nodes.append(contentsOf: walkTree(child, depth: depth + 1, maxDepth: maxDepth))
+        }
+    }
+    return nodes
+}
+
+func printNode(_ node: AXNode) {
+    let indent = String(repeating: "  ", count: node.depth)
+    var parts: [String] = []
+    if let role = node.role { parts.append("role=\(role)") }
+    if let subrole = node.subrole { parts.append("subrole=\(subrole)") }
+    if let title = node.title, !title.isEmpty { parts.append("title=\"\(title)\"") }
+    if let desc = node.description, !desc.isEmpty { parts.append("desc=\"\(desc)\"") }
+    if let id = node.identifier, !id.isEmpty { parts.append("id=\"\(id)\"") }
+    if let ph = node.placeholder, !ph.isEmpty { parts.append("placeholder=\"\(ph)\"") }
+    if let val = node.value {
+        let truncated = val.count > 50 ? String(val.prefix(50)) + "..." : val
+        parts.append("value=\"\(truncated)\"")
+    }
+    print("\(indent)\(parts.joined(separator: " | "))")
+}
+
+// MARK: - Find Text Input
+
+func findTextInputs(_ element: AXUIElement) -> [AXUIElement] {
+    let nodes = walkTree(element)
+    return nodes.compactMap { node in
+        guard let role = node.role else { return nil }
+        // Look for text areas, text fields, and web areas that might contain text input
+        if role == kAXTextAreaRole as String ||
+           role == kAXTextFieldRole as String ||
+           (role == "AXWebArea" && node.subrole == nil) {
+            return node.element
+        }
+        return nil
+    }
+}
+
+// MARK: - Actions
+
+func setText(_ element: AXUIElement, text: String) -> Bool {
+    let err = AXUIElementSetAttributeValue(element, kAXValueAttribute as CFString, text as CFTypeRef)
+    return err == .success
+}
+
+func focusElement(_ element: AXUIElement) -> Bool {
+    let err = AXUIElementSetAttributeValue(element, kAXFocusedAttribute as CFString, true as CFTypeRef)
+    return err == .success
+}
+
+func performPress(_ element: AXUIElement) -> Bool {
+    let err = AXUIElementPerformAction(element, kAXPressAction as CFString)
+    return err == .success
+}
+
+// MARK: - Main
+
+func main() {
+    let args = CommandLine.arguments
+
+    // Check accessibility trust
+    guard isTrusted() else {
+        print("ERROR: Accessibility permission not granted.")
+        print("Grant access in: System Settings > Privacy & Security > Accessibility")
+        print("Add Terminal.app (or your terminal emulator) to the allowed list.")
+        exit(1)
+    }
+
+    // Find Messages.app
+    guard let messagesApp = getMessagesApp() else {
+        print("ERROR: Messages.app is not running.")
+        print("Please open Messages.app first.")
+        exit(1)
+    }
+
+    print("Found Messages.app (PID: \(messagesApp.processIdentifier))")
+    let appElement = axElement(for: messagesApp)
+
+    // Mode: dump full tree
+    if args.contains("--dump") {
+        print("\n--- AX Tree Dump (max depth 8) ---\n")
+        let nodes = walkTree(appElement)
+        for node in nodes {
+            printNode(node)
+        }
+        print("\n--- End dump (\(nodes.count) nodes) ---")
+        return
+    }
+
+    // Find text inputs
+    let textInputs = findTextInputs(appElement)
+    print("Found \(textInputs.count) text input element(s)\n")
+
+    for (i, input) in textInputs.enumerated() {
+        let role = getRole(input) ?? "?"
+        let value = getValue(input) ?? "<empty>"
+        let placeholder = getPlaceholder(input) ?? "<none>"
+        let identifier = getIdentifier(input) ?? "<none>"
+        print("[\(i)] role=\(role) id=\(identifier) placeholder=\(placeholder) value=\"\(value)\"")
+    }
+
+    // Mode: set text
+    if let idx = args.firstIndex(of: "--set-text"), idx + 1 < args.count {
+        let text = args[idx + 1]
+        guard let firstInput = textInputs.first else {
+            print("\nERROR: No text input found to set text on.")
+            exit(1)
+        }
+        print("\nAttempting to set text to: \"\(text)\"")
+        let focused = focusElement(firstInput)
+        print("  Focus result: \(focused ? "OK" : "FAILED")")
+        let set = setText(firstInput, text: text)
+        print("  SetValue result: \(set ? "OK" : "FAILED")")
+
+        // Re-read value
+        let newValue = getValue(firstInput) ?? "<empty>"
+        print("  Current value: \"\(newValue)\"")
+
+        print("\n** CHECK: Did the remote recipient see a typing indicator? **")
+        return
+    }
+
+    // Mode: focus
+    if args.contains("--focus") {
+        guard let firstInput = textInputs.first else {
+            print("\nERROR: No text input found to focus.")
+            exit(1)
+        }
+        print("\nAttempting to focus text input...")
+        let result = focusElement(firstInput)
+        print("  Focus result: \(result ? "OK" : "FAILED")")
+
+        print("\n** CHECK: Did the remote recipient see a typing indicator? **")
+        return
+    }
+
+    // Default: just probe
+    if textInputs.isEmpty {
+        print("No text inputs found. Run with --dump to see the full AX tree.")
+    } else {
+        print("\nTo test typing indicator trigger:")
+        print("  swift ax-probe.swift --focus           # Focus the input field")
+        print("  swift ax-probe.swift --set-text \"hi\"   # Set text in the field")
+        print("  swift ax-probe.swift --dump            # Full AX tree dump")
+    }
+}
+
+main()

--- a/prototypes/ax-typing/node-integration.ts
+++ b/prototypes/ax-typing/node-integration.ts
@@ -37,28 +37,43 @@ const AX_BINARY = path.join(__dirname, "ax-typing-cli");
  */
 export async function startTypingViaAX(chatGuid: string): Promise<boolean> {
     try {
+        if (!isValidChatGuid(chatGuid)) {
+            console.warn(`AX typing: invalid chatGuid format`);
+            return false;
+        }
         // The Swift CLI handles finding the compose field and setting focus+text
-        const { stdout } = await execFileAsync(AX_BINARY, ["--start-typing", chatGuid], {
+        // Exit code 0 = success, non-zero = failure (structured protocol, not stdout parsing)
+        await execFileAsync(AX_BINARY, ["--start-typing", chatGuid], {
             timeout: 5000
         });
-        return stdout.includes("OK");
-    } catch (err) {
+        return true;
+    } catch (err: any) {
         // AX failures are non-fatal — typing indicators are nice-to-have
-        console.warn(`AX typing indicator failed: ${err}`);
+        console.warn(`AX typing indicator failed: ${err?.message ?? err}`);
         return false;
     }
 }
 
-export async function stopTypingViaAX(): Promise<boolean> {
+export async function stopTypingViaAX(chatGuid: string): Promise<boolean> {
     try {
-        const { stdout } = await execFileAsync(AX_BINARY, ["--stop-typing"], {
+        if (!isValidChatGuid(chatGuid)) {
+            console.warn(`AX stop typing: invalid chatGuid format`);
+            return false;
+        }
+        await execFileAsync(AX_BINARY, ["--stop-typing", chatGuid], {
             timeout: 5000
         });
-        return stdout.includes("OK");
-    } catch (err) {
-        console.warn(`AX stop typing failed: ${err}`);
+        return true;
+    } catch (err: any) {
+        console.warn(`AX stop typing failed: ${err?.message ?? err}`);
         return false;
     }
+}
+
+/** Validate chatGuid format to prevent injection via CLI args */
+function isValidChatGuid(guid: string): boolean {
+    // Expected formats: iMessage;-;+1234567890, iMessage;+;chat123456, SMS;-;+1234567890
+    return /^[a-zA-Z]+;[-+];[a-zA-Z0-9+@._-]+$/.test(guid);
 }
 
 /**

--- a/prototypes/ax-typing/node-integration.ts
+++ b/prototypes/ax-typing/node-integration.ts
@@ -1,0 +1,102 @@
+/**
+ * Node.js integration sketch for Accessibility API typing indicators.
+ *
+ * This is a CONCEPT — not production code. It shows how the AX approach
+ * would integrate into BlueBubbles server as an alternative to Private API
+ * typing indicators on macOS 26 Tahoe.
+ *
+ * Implementation options:
+ *   1. Shell out to the Swift CLI tool (simplest, ~15ms overhead)
+ *   2. Native Node addon using node-addon-api + Accessibility.framework
+ *   3. Use @electron/remote to call native macOS APIs from the Electron main process
+ *
+ * Option 1 is recommended for initial integration — it's the simplest and
+ * the performance is more than adequate (total cycle < 20ms).
+ */
+
+import { execFile } from "child_process";
+import { promisify } from "util";
+import path from "path";
+
+const execFileAsync = promisify(execFile);
+
+// Path to the compiled Swift binary (would be bundled with the server)
+const AX_BINARY = path.join(__dirname, "ax-typing-cli");
+
+/**
+ * Trigger a typing indicator by setting text in Messages.app's compose field.
+ *
+ * The approach:
+ *   1. Find Messages.app's compose field via AXUIElement query
+ *   2. Focus the field (required for some AX operations)
+ *   3. Set a placeholder value (triggers typing indicator on remote end — NEEDS VERIFICATION)
+ *   4. Optionally clear the field after a delay
+ *
+ * @param chatGuid - The chat to type in (used to select the right conversation)
+ * @returns true if the typing indicator was triggered successfully
+ */
+export async function startTypingViaAX(chatGuid: string): Promise<boolean> {
+    try {
+        // The Swift CLI handles finding the compose field and setting focus+text
+        const { stdout } = await execFileAsync(AX_BINARY, ["--start-typing", chatGuid], {
+            timeout: 5000
+        });
+        return stdout.includes("OK");
+    } catch (err) {
+        // AX failures are non-fatal — typing indicators are nice-to-have
+        console.warn(`AX typing indicator failed: ${err}`);
+        return false;
+    }
+}
+
+export async function stopTypingViaAX(): Promise<boolean> {
+    try {
+        const { stdout } = await execFileAsync(AX_BINARY, ["--stop-typing"], {
+            timeout: 5000
+        });
+        return stdout.includes("OK");
+    } catch (err) {
+        console.warn(`AX stop typing failed: ${err}`);
+        return false;
+    }
+}
+
+/**
+ * Check if AX typing indicators are available on this system.
+ *
+ * Requirements:
+ *   - macOS (darwin)
+ *   - Accessibility permission granted
+ *   - Messages.app running
+ *   - A conversation must be selected in Messages.app
+ */
+export async function isAXTypingAvailable(): Promise<{
+    available: boolean;
+    reason?: string;
+}> {
+    if (process.platform !== "darwin") {
+        return { available: false, reason: "Not macOS" };
+    }
+
+    try {
+        const { stdout } = await execFileAsync(AX_BINARY, ["--check"], {
+            timeout: 5000
+        });
+
+        if (stdout.includes("NO_PERMISSION")) {
+            return { available: false, reason: "Accessibility permission not granted" };
+        }
+        if (stdout.includes("NO_MESSAGES")) {
+            return { available: false, reason: "Messages.app not running" };
+        }
+        if (stdout.includes("NO_COMPOSE")) {
+            return { available: false, reason: "No conversation selected in Messages.app" };
+        }
+        if (stdout.includes("OK")) {
+            return { available: true };
+        }
+        return { available: false, reason: "Unknown state" };
+    } catch {
+        return { available: false, reason: "AX binary not found or not executable" };
+    }
+}


### PR DESCRIPTION
## Context
Private API typing indicators are dead on Tahoe (Launch Constraints block DYLIB injection, imagent XPC requires Apple-private entitlements). This explores the Accessibility API as an alternative.

## Prototype Results

| Capability | Works? | Performance |
|-----------|--------|-------------|
| Find compose field | YES (100%) | 5.7-12ms |
| Focus field | YES | 0.2ms |
| Set text | YES | 0.3ms |
| Full typing cycle | YES | 1.9ms |
| **Background operation** | **YES** | — |

No DYLIB injection, no private entitlements, no foreground requirement.

## Pending
Manual verification needed: does `AXSetValue` on the compose field trigger a typing indicator on the remote end? Requires testing with a second device.

## Files
- `prototypes/ax-typing/ax-probe.swift` — interactive probe
- `prototypes/ax-typing/ax-benchmark.swift` — performance benchmarks
- `prototypes/ax-typing/node-integration.ts` — Node.js integration concept
- `docs/research/2026-04-14-ax-typing-indicators.md` — full research doc

Ref #20