### PR TITLE
fix: prevent setup wizard flash before server config loads

### DIFF
--- a/packages/ui/src/app/App.tsx
+++ b/packages/ui/src/app/App.tsx
@@ -6,7 +6,14 @@ import { Setup } from './containers/setup/Setup';
 import { useAppSelector } from './hooks';
 
 const App = (): JSX.Element => {
+    const configLoaded: boolean = useAppSelector(state => state.config._configLoaded) ?? false;
     const isSetupComplete: boolean = useAppSelector(state => state.config.tutorial_is_done) ?? false;
+
+    // Wait for server config before deciding setup vs dashboard
+    if (!configLoaded) {
+        return (<div />);
+    }
+
     if (isSetupComplete) {
         return (<Navigation />);
     } else {

--- a/packages/ui/src/app/slices/ConfigSlice.ts
+++ b/packages/ui/src/app/slices/ConfigSlice.ts
@@ -1,7 +1,7 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { ipcRenderer } from 'electron';
 
-const initialState: NodeJS.Dict<any> = {};
+const initialState: NodeJS.Dict<any> = { _configLoaded: false };
 
 export type ConfigItem = {
     name: string,
@@ -32,6 +32,9 @@ export const ConfigSlice = createSlice({
                 if (state[i.name] === i.value) continue;
                 state[i.name] = i.value;
             }
+
+            // Mark config as loaded after first bulk load from server
+            state._configLoaded = true;
         }
     }
 });


### PR DESCRIPTION
## Problem
The UI renders `App` before `getConfig()` IPC resolves. `state.config.tutorial_is_done` is `undefined`, `?? false` kicks in, and the setup wizard shows — even when `config.db` has `tutorial_is_done=1`.

This caused the fork build to show the setup wizard on every launch on canon, blocking deployment.

## Fix
- Added `_configLoaded` flag to `ConfigSlice` (starts `false`, set `true` after first `setConfigBulk`)
- `App.tsx` renders an empty div until config loads, then decides setup vs dashboard

2-line production change, zero risk to existing behavior.