### PR TITLE
fix: preserve class names in production builds for typeorm

### DIFF
--- a/packages/server/scripts/webpack.main.prod.config.js
+++ b/packages/server/scripts/webpack.main.prod.config.js
@@ -1,7 +1,18 @@
 const { merge } = require('webpack-merge');
+const TerserPlugin = require('terser-webpack-plugin');
 
 const baseConfig = require('./webpack.main.config');
 
 module.exports = merge(baseConfig, {
-    mode: 'production'
+    mode: 'production',
+    optimization: {
+        minimizer: [
+            new TerserPlugin({
+                terserOptions: {
+                    keep_classnames: true,
+                    keep_fnames: true,
+                },
+            }),
+        ],
+    },
 });


### PR DESCRIPTION
## Root Cause

Webpack production mode enables Terser which mangles class names (e.g., `Chat` → `Bo`). TypeORM uses class names as entity metadata keys, so `getRepository(Chat)` fails with `No metadata for 'Bo'`.

This breaks `/api/v1/server/info` (HTTP 500), which is used by openclaw-infra deploy smoke tests — blocking all deploys.

## Fix

Configure TerserPlugin with `keep_classnames: true` and `keep_fnames: true` in `webpack.main.prod.config.js`.

## Impact

**Critical** — blocks openclaw-infra deploys (bb-connectivity smoke test fails).

Closes #32