### PR TITLE
fix: resolve webpack production build TS errors

### DIFF
--- a/packages/server/src/server/api/interfaces/iCloudInterface.ts
+++ b/packages/server/src/server/api/interfaces/iCloudInterface.ts
@@ -24,7 +24,7 @@ export class iCloudInterface {
         const data = await Server().privateApi.cloud.getContactCard(address);
         const avatarPath = data?.data?.avatar_path;
         if (isNotEmpty(avatarPath) && loadAvatar) {
-            data.data.avatar = bytesToBase64(fs.readFileSync(avatarPath));
+            data.data.avatar = bytesToBase64(fs.readFileSync(avatarPath) as unknown as Uint8Array);
             delete data.data.avatar_path;
         }
 

--- a/packages/server/src/server/utils/CryptoUtils.ts
+++ b/packages/server/src/server/utils/CryptoUtils.ts
@@ -1,10 +1,11 @@
 import { createHash, randomBytes } from "crypto";
 
-
 export const generateMd5Hash = (data: Buffer): string => {
-    return createHash("md5").update(data).digest("hex");
+    return createHash("md5")
+        .update(data as unknown as Uint8Array)
+        .digest("hex");
 };
 
 export const generateRandomString = (length: number): string => {
-    return randomBytes(Math.ceil(length / 2)).toString('hex');
+    return randomBytes(Math.ceil(length / 2)).toString("hex");
 };

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -6,7 +6,7 @@
             "@server": ["server/index"],
             "@server/*": ["server/*"],
             "@windows/*": ["windows/*"],
-            "@trays/*": ["trays/*"],
+            "@trays/*": ["trays/*"]
         },
         "outDir": "./dist",
         "strictNullChecks": false,
@@ -14,5 +14,5 @@
         "emitDecoratorMetadata": true
     },
     "include": ["src"],
-    "exclude": ["dist", "node_modules", "*.js", "tsconfig.json"]
+    "exclude": ["dist", "node_modules", "*.js", "tsconfig.json", "src/**/__tests__/**", "src/**/*.test.ts"]
 }


### PR DESCRIPTION
Pre-existing TS errors that block `npm run build` on Node 22:

1. **Buffer/Uint8Array cast** — Node 22's stricter typing rejects `Buffer` where `Uint8Array` is expected. Added `as unknown as Uint8Array` casts in `CryptoUtils.ts` and `iCloudInterface.ts`.
2. **Test files in build scope** — `tsconfig.json` included `src/**` which pulls in `__tests__` directories. Added excludes for test patterns.

Unblocks production builds for PRs #36 and #38.