### PR TITLE
fix: disable terser mangling to prevent decorator TDZ errors

### DIFF
--- a/packages/server/scripts/webpack.main.prod.config.js
+++ b/packages/server/scripts/webpack.main.prod.config.js
@@ -11,6 +11,16 @@ module.exports = merge(baseConfig, {
                 terserOptions: {
                     keep_classnames: true,
                     keep_fnames: true,
+                    // Disable mangling and aggressive compression — decorator
+                    // metadata emits references that depend on declaration order.
+                    // Terser's reordering causes TDZ errors (e.g. "Cannot access
+                    // 'fa' before initialization"). Bundle size is irrelevant for
+                    // a server-side Electron app.
+                    mangle: false,
+                    compress: {
+                        collapse_vars: false,
+                        reduce_vars: false,
+                    },
                 },
             }),
         ],


### PR DESCRIPTION
## Problem

Production build crashes at startup:

```
ReferenceError: Cannot access 'fa' before initialization
```

Terser's variable mangling reorders `let`/`const` declarations. The `babel-plugin-transform-typescript-metadata` (PR #36) emits code that references class constructors in declaration order — Terser's `collapse_vars` and `reduce_vars` optimizations break this, causing temporal dead zone errors.

## Fix

Disable `mangle` and the aggressive compression passes (`collapse_vars`, `reduce_vars`). Bundle size is irrelevant for a server-side Electron app (~451KB → ~1.2MB, still tiny).

## Testing

Needs rebuild on canon and verify BB starts without TDZ errors.