### PR TITLE
fix: remove babel-plugin-transform-typescript-metadata (causes TDZ errors)

### DIFF
--- a/packages/server/scripts/webpack.main.config.js
+++ b/packages/server/scripts/webpack.main.config.js
@@ -32,8 +32,6 @@ module.exports = merge(baseConfig, {
                         "@babel/preset-typescript"
                     ],
                     plugins: [
-                        // Must be BEFORE decorators — captures TypeORM reflect-metadata
-                        "babel-plugin-transform-typescript-metadata",
                         ["@babel/plugin-proposal-decorators", { legacy: true }],
                         [
                             "@babel/plugin-transform-class-properties",

--- a/packages/server/scripts/webpack.main.prod.config.js
+++ b/packages/server/scripts/webpack.main.prod.config.js
@@ -11,16 +11,6 @@ module.exports = merge(baseConfig, {
                 terserOptions: {
                     keep_classnames: true,
                     keep_fnames: true,
-                    // Disable mangling and aggressive compression — decorator
-                    // metadata emits references that depend on declaration order.
-                    // Terser's reordering causes TDZ errors (e.g. "Cannot access
-                    // 'fa' before initialization"). Bundle size is irrelevant for
-                    // a server-side Electron app.
-                    mangle: false,
-                    compress: {
-                        collapse_vars: false,
-                        reduce_vars: false,
-                    },
                 },
             }),
         ],


### PR DESCRIPTION
## Problem

Production builds crash at startup with TDZ errors:

```
ReferenceError: Cannot access 'Contact' before initialization
```

`babel-plugin-transform-typescript-metadata` (PR #36) emits `Reflect.metadata('design:type', Contact)` calls that reference entity classes. With circular dependencies between entities (Contact ↔ ContactAddress, Message ↔ Handle), webpack concatenates these into a single scope where declaration order can't satisfy all references.

## Why it's safe to remove

BB entities specify all column types explicitly (`@Column({ type: 'text' })`) and use arrow functions for relations (`() => Contact`). TypeORM does **not** need `emitDecoratorMetadata` when types are explicit — `keep_classnames` alone preserves the entity names TypeORM uses for metadata lookup.

## Changes

1. Remove `babel-plugin-transform-typescript-metadata` from webpack babel plugins
2. Revert `mangle: false` and `compress` overrides from PR #40 (were workarounds for this plugin)
3. Keep `keep_classnames: true` + `keep_fnames: true` in TerserPlugin (the actual #32 fix)

Closes #32