### PR TITLE
fix: restore babel TypeORM metadata plugin + terser TDZ safeguards

### DIFF
--- a/packages/server/scripts/webpack.main.config.js
+++ b/packages/server/scripts/webpack.main.config.js
@@ -32,6 +32,13 @@ module.exports = merge(baseConfig, {
                         "@babel/preset-typescript"
                     ],
                     plugins: [
+                        // Must be BEFORE decorators — emits Reflect.metadata calls
+                        // that TypeORM needs for runtime entity type resolution.
+                        // Without this, @Column() decorators lack type info and
+                        // TypeORM throws "No metadata for Chat" at runtime.
+                        // Terser's mangle/collapse/reduce_vars must be disabled
+                        // in prod config to prevent TDZ errors from metadata refs.
+                        "babel-plugin-transform-typescript-metadata",
                         ["@babel/plugin-proposal-decorators", { legacy: true }],
                         [
                             "@babel/plugin-transform-class-properties",

--- a/packages/server/scripts/webpack.main.prod.config.js
+++ b/packages/server/scripts/webpack.main.prod.config.js
@@ -11,6 +11,18 @@ module.exports = merge(baseConfig, {
                 terserOptions: {
                     keep_classnames: true,
                     keep_fnames: true,
+                    // Disable mangling and aggressive compression — the
+                    // babel-plugin-transform-typescript-metadata plugin emits
+                    // Reflect.metadata('design:type', Contact) references that
+                    // create variable dependencies. Terser's reordering and
+                    // renaming causes TDZ errors ("Cannot access 'fa' before
+                    // initialization"). Bundle size is irrelevant for a
+                    // server-side Electron app; correctness > size.
+                    mangle: false,
+                    compress: {
+                        collapse_vars: false,
+                        reduce_vars: false,
+                    },
                 },
             }),
         ],


### PR DESCRIPTION
Reverts PR #41's removal of `babel-plugin-transform-typescript-metadata`.

## Problem

Without the plugin, TypeORM entity decorators (e.g. `@Column()`, `@Entity()`, `@OneToMany`) lack runtime type information via `Reflect.getMetadata('design:type', ...)`. This causes **"No metadata for Chat was found"** errors on every endpoint that hits the entity manager (e.g. `/api/v1/server/info`).

**Verified empirically:** v1.11.11 (plugin present, terser mangling off) works. v1.11.12+ (plugin removed) fails. The fix re-adds both.

## Solution

1. Re-add `babel-plugin-transform-typescript-metadata` to `webpack.main.config.js`
2. Re-add terser `mangle: false` + `compress.collapse_vars: false` + `compress.reduce_vars: false` to `webpack.main.prod.config.js`

The plugin emits `Reflect.metadata(...)` calls that reference entity classes. Without the terser settings, variable mangling reorders/renames these refs causing TDZ errors. With the terser settings, declaration order is preserved.

## Tradeoff

Bundle size is ~3x larger without mangling, but that doesn't matter for a server-side Electron app. Correctness > size.

## Testing

Will be verified on canon after merge — rebuild + install + check `/api/v1/server/info` returns 200.