### PR TITLE
fix(types): use ReturnType<typeof setInterval> for interval handle

### DIFF
--- a/packages/server/src/server/lib/ScheduledService.ts
+++ b/packages/server/src/server/lib/ScheduledService.ts
@@ -5,7 +5,7 @@ export class ScheduledService extends EventEmitter {
 
     action: () => void;
 
-    handle: NodeJS.Timer;
+    handle: ReturnType<typeof setInterval>;
 
     interval: number;
 


### PR DESCRIPTION
@types/node v25+ made `NodeJS.Timer` no longer assignable to `clearInterval`'s parameter (which now expects `NodeJS.Timeout`). `ReturnType<typeof setInterval>` is version-agnostic.

Discovered when rebuilding on canon with `@types/node` v25.6.0.