### PR TITLE
fix: revert PR #45 — plugin re-add caused TDZ errors on startup

### DIFF
--- a/packages/server/scripts/webpack.main.config.js
+++ b/packages/server/scripts/webpack.main.config.js
@@ -32,13 +32,6 @@ module.exports = merge(baseConfig, {
                         "@babel/preset-typescript"
                     ],
                     plugins: [
-                        // Must be BEFORE decorators — emits Reflect.metadata calls
-                        // that TypeORM needs for runtime entity type resolution.
-                        // Without this, @Column() decorators lack type info and
-                        // TypeORM throws "No metadata for Chat" at runtime.
-                        // Terser's mangle/collapse/reduce_vars must be disabled
-                        // in prod config to prevent TDZ errors from metadata refs.
-                        "babel-plugin-transform-typescript-metadata",
                         ["@babel/plugin-proposal-decorators", { legacy: true }],
                         [
                             "@babel/plugin-transform-class-properties",

--- a/packages/server/scripts/webpack.main.prod.config.js
+++ b/packages/server/scripts/webpack.main.prod.config.js
@@ -11,18 +11,6 @@ module.exports = merge(baseConfig, {
                 terserOptions: {
                     keep_classnames: true,
                     keep_fnames: true,
-                    // Disable mangling and aggressive compression — the
-                    // babel-plugin-transform-typescript-metadata plugin emits
-                    // Reflect.metadata('design:type', Contact) references that
-                    // create variable dependencies. Terser's reordering and
-                    // renaming causes TDZ errors ("Cannot access 'fa' before
-                    // initialization"). Bundle size is irrelevant for a
-                    // server-side Electron app; correctness > size.
-                    mangle: false,
-                    compress: {
-                        collapse_vars: false,
-                        reduce_vars: false,
-                    },
                 },
             }),
         ],


### PR DESCRIPTION
## Problem

PR #45 restored `babel-plugin-transform-typescript-metadata` to fix "No metadata for Chat" errors. But the plugin causes **TDZ errors during module initialization** that prevent BB from starting entirely — the process runs but never listens on the HTTP port, stuck at ~150MB memory with 0% CPU.

Even the terser `mangle: false` + `collapse_vars: false` + `reduce_vars: false` settings (which were supposedly the fix in PR #40) don't prevent this TDZ issue — they only reduce it.

## Evidence

- v1.12.2 (PR #45 applied, with plugin): BB process starts, never listens, silent failure
- v1.11.11 (no plugin, no mangle): BB starts and listens correctly

## Approach going forward

The plugin-less approach (relying on `keep_classnames` + explicit entity types per PR #41's claim) does work for some endpoints but still errors on Chat-specific queries. Need a proper fix — likely switching to `ts-loader` or `@swc/loader` with `emitDecoratorMetadata: true` so TS's own decorator metadata emission handles it without TDZ issues from babel.

Filing follow-up issue to investigate ts-loader migration.

## Revert scope

Reverts 6e2edb1b entirely.