### PR TITLE
feat(ax-helper): apply tapback via named AX action on message

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Fork of [BlueBubblesApp/bluebubbles-server](https://github.com/BlueBubblesApp/bl
 
 ### ax-helper (Tahoe Private API Alternative)
 
-The Private API (DYLIB injection) is dead on macOS 26 due to Launch Constraints. `ax-helper` is a Swift CLI binary that uses Accessibility API menu item invocation as an alternative.
+The Private API (DYLIB injection) is dead on macOS 26 due to Launch Constraints. `ax-helper` is a Swift CLI binary that uses the Accessibility API as an alternative — named AX actions on message elements for tapbacks, menu item invocation for mark-as-read and conversation navigation.
 
 **REST Endpoints:**
 

--- a/packages/server/appResources/ax-helper/Sources/AXHelper.swift
+++ b/packages/server/appResources/ax-helper/Sources/AXHelper.swift
@@ -66,7 +66,7 @@ enum AXHelper {
 
     private static func getIdentifier(_ element: AXUIElement) -> String? {
         var value: AnyObject?
-        let err = AXUIElementCopyAttributeValue(element, "AXIdentifier" as CFString, &value)
+        let err = AXUIElementCopyAttributeValue(element, kAXIdentifierAttribute as CFString, &value)
         return err == .success ? (value as? String) : nil
     }
 

--- a/packages/server/appResources/ax-helper/Sources/main.swift
+++ b/packages/server/appResources/ax-helper/Sources/main.swift
@@ -1,9 +1,19 @@
 import Foundation
 import ApplicationServices
-import CoreGraphics
 
 let args = CommandLine.arguments
 let startTime = DispatchTime.now()
+
+// Named AX actions exposed on iMessage bubbles (AXGroup id='Sticker') for
+// every reaction type. Used by the tapback command.
+let tapbackActionNames: [String: String] = [
+    "heart": "Heart",
+    "thumbsup": "Thumbs up",
+    "thumbsdown": "Thumbs down",
+    "haha": "Ha ha!",
+    "emphasis": "Exclamation mark",
+    "question": "Question mark"
+]
 
 var traceId: String? = nil
 if let idx = args.firstIndex(of: "--trace-id"), idx + 1 < args.count {
@@ -84,21 +94,13 @@ case "tapback":
     // On macOS Tahoe, each message (AXGroup id='Sticker') exposes named AX
     // actions for every reaction. Performing the action applies the tapback
     // directly — no picker UI, no menu bar, no keyboard simulation.
-    let tapbackActionNames: [String: String] = [
-        "heart": "Heart",
-        "thumbsup": "Thumbs up",
-        "thumbsdown": "Thumbs down",
-        "haha": "Ha ha!",
-        "emphasis": "Exclamation mark",
-        "question": "Question mark"
-    ]
     guard let actionName = tapbackActionNames[tapbackType] else {
         writeError("Invalid tapback type: \(tapbackType). Valid: \(Array(tapbackActionNames.keys).sorted().joined(separator: ", "))")
+        writeJSON(OutputResult(ok: false, op: "tapback", error: "invalid_tapback_type", ms: elapsed(), trace: traceId))
         exit(ExitCode.invalidArguments.rawValue)
     }
     let messages = requireMessages()
-    let pid = messages.app.processIdentifier
-    let appRef = AXUIElementCreateApplication(pid)
+    let appRef = messages.element
 
     func attr(_ e: AXUIElement, _ key: String) -> Any? {
         var v: CFTypeRef?
@@ -107,9 +109,12 @@ case "tapback":
 
     // Find the most recent message in the conversation. AXGroup id='Sticker'
     // is the stable identifier; the last match in tree order is the newest.
+    // Depth limit prevents runaway recursion on pathological AX trees; the
+    // Messages.app tree depth from window root to message bubble is well
+    // within this bound on Tahoe.
     func findLastMessage(_ e: AXUIElement, depth: Int = 0, maxDepth: Int = 25) -> AXUIElement? {
-        guard depth <= maxDepth else { return nil }
-        var best: AXUIElement? = nil
+        guard depth < maxDepth else { return nil }
+        var best: AXUIElement?
         let role = attr(e, kAXRoleAttribute) as? String ?? ""
         let ident = attr(e, kAXIdentifierAttribute) as? String ?? ""
         if role == "AXGroup" && ident == "Sticker" { best = e }
@@ -120,10 +125,18 @@ case "tapback":
         return best
     }
 
-    let windows = attr(appRef, kAXWindowsAttribute) as? [AXUIElement] ?? []
-    var target: AXUIElement? = nil
-    for w in windows {
-        if let m = findLastMessage(w) { target = m }
+    // Prefer the focused window; fall back to iterating all windows if focus
+    // is not resolvable. Multi-window setups (detached chat windows) can
+    // otherwise tapback the wrong conversation.
+    var target: AXUIElement?
+    if let focusedAny = attr(appRef, kAXFocusedWindowAttribute) {
+        target = findLastMessage(focusedAny as! AXUIElement)
+    }
+    if target == nil {
+        let windows = attr(appRef, kAXWindowsAttribute) as? [AXUIElement] ?? []
+        for w in windows {
+            if let m = findLastMessage(w) { target = m }
+        }
     }
     guard let message = target else {
         writeError("Could not find a message (AXGroup id='Sticker') in Messages.app window")
@@ -133,10 +146,14 @@ case "tapback":
 
     // Verify the action is exposed on the target message
     var actionsRef: CFArray?
-    AXUIElementCopyActionNames(message, &actionsRef)
+    let actionsErr = AXUIElementCopyActionNames(message, &actionsRef)
+    guard actionsErr == .success else {
+        writeError("AXUIElementCopyActionNames failed: \(actionsErr.rawValue)")
+        writeJSON(OutputResult(ok: false, op: "tapback", error: "ax_copy_actions_failed_\(actionsErr.rawValue)", ms: elapsed(), trace: traceId))
+        exit(ExitCode.operationFailed.rawValue)
+    }
     let availableActions = (actionsRef as? [String]) ?? []
-    let hasAction = availableActions.contains { $0.contains(actionName) }
-    guard hasAction else {
+    guard availableActions.contains(actionName) else {
         writeError("Message does not expose action '\(actionName)'. Available: \(availableActions)")
         writeJSON(OutputResult(ok: false, op: "tapback", error: "action_not_available", ms: elapsed(), trace: traceId))
         exit(ExitCode.operationFailed.rawValue)

--- a/packages/server/appResources/ax-helper/Sources/main.swift
+++ b/packages/server/appResources/ax-helper/Sources/main.swift
@@ -1,5 +1,6 @@
 import Foundation
 import ApplicationServices
+import CoreGraphics
 
 let args = CommandLine.arguments
 let startTime = DispatchTime.now()
@@ -80,17 +81,74 @@ case "tapback":
         exit(ExitCode.invalidArguments.rawValue)
     }
     let tapbackType = args[2]
-    let validTypes = ["heart", "thumbsup", "thumbsdown", "haha", "emphasis", "question"]
-    guard validTypes.contains(tapbackType) else {
-        writeError("Invalid tapback type: \(tapbackType). Valid: \(validTypes.joined(separator: ", "))")
+    // On macOS Tahoe, each message (AXGroup id='Sticker') exposes named AX
+    // actions for every reaction. Performing the action applies the tapback
+    // directly — no picker UI, no menu bar, no keyboard simulation.
+    let tapbackActionNames: [String: String] = [
+        "heart": "Heart",
+        "thumbsup": "Thumbs up",
+        "thumbsdown": "Thumbs down",
+        "haha": "Ha ha!",
+        "emphasis": "Exclamation mark",
+        "question": "Question mark"
+    ]
+    guard let actionName = tapbackActionNames[tapbackType] else {
+        writeError("Invalid tapback type: \(tapbackType). Valid: \(Array(tapbackActionNames.keys).sorted().joined(separator: ", "))")
         exit(ExitCode.invalidArguments.rawValue)
     }
     let messages = requireMessages()
-    let menuBar = requireMenuBar(messages)
-    pressMenuItemByName(menuBar, name: "tapback", op: "tapback")
-    // Note: tapback picker appears — the actual type selection requires
-    // further AX interaction with the picker UI. For now, pressing the
-    // menu item opens the picker. Type selection is a future enhancement.
+    let pid = messages.app.processIdentifier
+    let appRef = AXUIElementCreateApplication(pid)
+
+    func attr(_ e: AXUIElement, _ key: String) -> Any? {
+        var v: CFTypeRef?
+        return AXUIElementCopyAttributeValue(e, key as CFString, &v) == .success ? (v as Any?) : nil
+    }
+
+    // Find the most recent message in the conversation. AXGroup id='Sticker'
+    // is the stable identifier; the last match in tree order is the newest.
+    func findLastMessage(_ e: AXUIElement, depth: Int = 0, maxDepth: Int = 25) -> AXUIElement? {
+        guard depth <= maxDepth else { return nil }
+        var best: AXUIElement? = nil
+        let role = attr(e, kAXRoleAttribute) as? String ?? ""
+        let ident = attr(e, kAXIdentifierAttribute) as? String ?? ""
+        if role == "AXGroup" && ident == "Sticker" { best = e }
+        let kids = attr(e, kAXChildrenAttribute) as? [AXUIElement] ?? []
+        for k in kids {
+            if let found = findLastMessage(k, depth: depth + 1, maxDepth: maxDepth) { best = found }
+        }
+        return best
+    }
+
+    let windows = attr(appRef, kAXWindowsAttribute) as? [AXUIElement] ?? []
+    var target: AXUIElement? = nil
+    for w in windows {
+        if let m = findLastMessage(w) { target = m }
+    }
+    guard let message = target else {
+        writeError("Could not find a message (AXGroup id='Sticker') in Messages.app window")
+        writeJSON(OutputResult(ok: false, op: "tapback", error: "no_message_found", ms: elapsed(), trace: traceId))
+        exit(ExitCode.operationFailed.rawValue)
+    }
+
+    // Verify the action is exposed on the target message
+    var actionsRef: CFArray?
+    AXUIElementCopyActionNames(message, &actionsRef)
+    let availableActions = (actionsRef as? [String]) ?? []
+    let hasAction = availableActions.contains { $0.contains(actionName) }
+    guard hasAction else {
+        writeError("Message does not expose action '\(actionName)'. Available: \(availableActions)")
+        writeJSON(OutputResult(ok: false, op: "tapback", error: "action_not_available", ms: elapsed(), trace: traceId))
+        exit(ExitCode.operationFailed.rawValue)
+    }
+
+    let result = AXUIElementPerformAction(message, actionName as CFString)
+    guard result == .success else {
+        writeError("AXPerformAction('\(actionName)') on message failed: \(result.rawValue)")
+        writeJSON(OutputResult(ok: false, op: "tapback", error: "ax_perform_failed_\(result.rawValue)", ms: elapsed(), trace: traceId))
+        exit(ExitCode.operationFailed.rawValue)
+    }
+
     writeJSON(OutputResult(ok: true, op: "tapback", type: tapbackType, ms: elapsed(), trace: traceId))
 
 case "mark-read":

--- a/packages/server/appResources/ax-helper/Tests/AXHelperTests/CLITests.swift
+++ b/packages/server/appResources/ax-helper/Tests/AXHelperTests/CLITests.swift
@@ -53,11 +53,18 @@ struct ArgumentParsingTests {
         #expect(result.stderr.contains("Usage:"))
     }
 
-    @Test("Tapback invalid type exits 3")
+    @Test("Tapback invalid type exits 3 and emits invalid_tapback_type JSON")
     func tapbackInvalidTypeExits3() throws {
         let result = try Self.runCLI(["tapback", "invalid"])
         #expect(result.exitCode == 3)
         #expect(result.stderr.contains("Invalid tapback type"))
+        // Stdout must carry the JSON error — callers parse stdout and need a
+        // structured payload even on argument-validation failures.
+        let data = result.stdout.data(using: .utf8)!
+        let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+        #expect(json["ok"] as? Bool == false)
+        #expect(json["op"] as? String == "tapback")
+        #expect(json["error"] as? String == "invalid_tapback_type")
     }
 
     @Test("Navigate missing direction exits 3")

--- a/packages/server/appResources/ax-helper/Tests/AXHelperTests/CLITests.swift
+++ b/packages/server/appResources/ax-helper/Tests/AXHelperTests/CLITests.swift
@@ -77,8 +77,14 @@ struct ArgumentParsingTests {
 @Suite("JSON Output Format")
 struct JSONOutputTests {
 
-    @Test("Tapback with valid args produces valid JSON with op and trace")
-    func tapbackOutputIsValidJSON() throws {
+    // Contract/shape test only — asserts the JSON structure of tapback output
+    // regardless of whether the operation succeeded. In a test environment
+    // without Messages.app running, this falls through to the error path; both
+    // {ok:true,type:...} and {ok:false,error:...} shapes are accepted. A
+    // behavioral test requires mocking Messages.app's AX tree, which is out
+    // of scope here.
+    @Test("Tapback output JSON has the expected shape")
+    func tapbackOutputHasExpectedShape() throws {
         let result = try ArgumentParsingTests.runCLI(["tapback", "heart", "--trace-id", "test123"])
         // Exit code should NOT be 3 (invalid args) — it passed argument validation
         #expect(result.exitCode != 3)

--- a/packages/server/src/server/services/__tests__/AxService.test.ts
+++ b/packages/server/src/server/services/__tests__/AxService.test.ts
@@ -152,10 +152,10 @@ describe("AxService", () => {
             mockExecFile.mockImplementation((_cmd: string, _args: string[], _opts: any, cb: Function) => {
                 const error: any = new Error("exit code 1");
                 error.code = 1;
-                cb(error, '{"ok":false,"op":"tapback","error":"menu_item_disabled"}', "Menu item disabled");
+                cb(error, '{"ok":false,"op":"tapback","error":"action_not_available"}', "Action not available");
             });
 
-            await expect(service.tapback("heart", "t1")).rejects.toThrow("menu_item_disabled");
+            await expect(service.tapback("heart", "t1")).rejects.toThrow("action_not_available");
         });
 
         it("rejects on timeout", async () => {


### PR DESCRIPTION
## Summary

Tapback reactions now work end-to-end via Messages.app's Accessibility API. Each iMessage bubble (`AXGroup id='Sticker'`) exposes named AX actions for every reaction — `Heart`, `Thumbs up`, `Thumbs down`, `Ha ha!`, `Exclamation mark`, `Question mark`. Invoking the action directly on the message element applies the tapback with no UI interaction required.

## Why this approach

We tried three dead-end approaches first:

1. **Menu bar** — the `tapback_last_message` menu item does not exist on macOS Tahoe.
2. **CGEvent keystrokes** — cross-process keystroke delivery to the picker fails in practice.
3. **AXShowMenu on the message** — opens the context menu, not the tapback picker.

Named AX actions are the simplest and most reliable path. No picker UI ever opens, so there's no race and no focus dependency.

## Changes

- `packages/server/appResources/ax-helper/Sources/main.swift` — rewrite the `tapback` case to find the last `AXGroup id='Sticker'` in Messages.app's window tree, verify the target reaction's named action is exposed, and invoke it via `AXUIElementPerformAction`.

## Verification

End-to-end tested on canon (macOS 26 Tahoe, BlueBubbles v1.12.1, ad-hoc-signed ax-helper):

- `POST /api/v1/ax/tapback { type: "thumbsup" }` lands the reaction on the most recent message. Confirmed visually.
- Unknown reaction types return `invalid_arguments`.
- Missing message returns `no_message_found`.
- Missing action on message returns `action_not_available` with the available actions list.