### PR TITLE
feat: expose on-device audio-message transcription via GET /api/v1/message/audio-transcript/:guid

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,17 @@ Voice notes received in Messages.app are transcribed on-device by iOS/macOS (sin
 }
 ```
 
-**Error responses:** `400 invalid_guid`, `404 not_found`, `404 no_transcription` (attachment exists but lacks a transcript — e.g. older message or non-audio attachment), `500 invalid_plist`, `500 fetch_error`. Callers should inspect the `error` field in the response body to distinguish `not_found` from `no_transcription`.
+**Error response shape:**
+
+```json
+{
+  "status": 404,
+  "message": "audio-transcript no_transcription",
+  "error": { "type": "DATABASE_ERROR", "message": "no_transcription" }
+}
+```
+
+**Error codes:** `400 invalid_guid`, `404 not_found`, `404 no_transcription` (attachment exists but lacks a transcript — e.g. older message or non-audio attachment), `500 invalid_plist`, `500 fetch_error`. Callers should inspect the `error.message` field in the response body to distinguish `not_found` from `no_transcription`.
 
 ## Pre-requisites
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,31 @@ The Private API (DYLIB injection) is dead on macOS 26 due to Launch Constraints.
 
 **Limitations:** Typing indicators and read receipt delivery are not achievable on Tahoe. See `docs/research/2026-04-14-private-api-tahoe.md` for the full research findings.
 
+### Audio Message Transcripts
+
+Voice notes received in Messages.app are transcribed on-device by iOS/macOS (since Sonoma) and the resulting text is stored in `attachment.user_info`. This endpoint reads that transcript directly — no Whisper, no third-party STT, no network roundtrip beyond the DB query.
+
+**REST Endpoint:**
+
+- `GET /api/v1/message/audio-transcript/:guid` — Fetch Apple's on-device transcription for an audio-message attachment
+
+**Response (200):**
+
+```json
+{
+  "status": 200,
+  "data": {
+    "ok": true,
+    "guid": "at_0_ABC",
+    "transcript": "Hey, just checking in.",
+    "uti": "com.apple.coreaudio-format",
+    "filename": "Audio Message.caf"
+  }
+}
+```
+
+**Error responses:** `400 invalid_guid`, `404 not_found`, `404 no_transcription` (attachment exists but lacks a transcript — e.g. older message or non-audio attachment), `500 invalid_plist`, `500 fetch_error`. Callers should inspect the `error` field in the response body to distinguish `not_found` from `no_transcription`.
+
 ## Pre-requisites
 
 - Node.js 20+

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -79,6 +79,7 @@
     },
     "dependencies": {
         "@firebase/app-types": "^0.9.0",
+        "bplist-parser": "^0.3.2",
         "@firebase/util": "^1.9.3",
         "@peculiar/x509": "^1.6.1",
         "async-sema": "^3.1.1",

--- a/packages/server/src/server/api/http/api/v1/httpRoutes.ts
+++ b/packages/server/src/server/api/http/api/v1/httpRoutes.ts
@@ -543,6 +543,7 @@ export class HttpRoutes {
                     {
                         method: HttpMethod.GET,
                         path: "audio-transcript/:guid",
+                        middleware: [...HttpRoutes.protected],
                         controller: MessageRouter.audioTranscript
                     }
                 ]

--- a/packages/server/src/server/api/http/api/v1/httpRoutes.ts
+++ b/packages/server/src/server/api/http/api/v1/httpRoutes.ts
@@ -539,6 +539,11 @@ export class HttpRoutes {
                         middleware: [...HttpRoutes.protected, PrivateApiMiddleware],
                         validators: [MessageValidator.validateGetEmbeddedMedia],
                         controller: MessageRouter.getEmbeddedMedia
+                    },
+                    {
+                        method: HttpMethod.GET,
+                        path: "audio-transcript/:guid",
+                        controller: MessageRouter.audioTranscript
                     }
                 ]
             },

--- a/packages/server/src/server/api/http/api/v1/routers/messageRouter.ts
+++ b/packages/server/src/server/api/http/api/v1/routers/messageRouter.ts
@@ -9,14 +9,16 @@ import { Server } from "@server";
 import { FileSystem } from "@server/fileSystem";
 import { isEmpty, isNotEmpty, isTruthyBool } from "@server/helpers/utils";
 import { Message } from "@server/databases/imessage/entity/Message";
+import { Attachment } from "@server/databases/imessage/entity/Attachment";
 import { MessageInterface } from "@server/api/interfaces/messageInterface";
 import { MessagePromiseRejection } from "@server/managers/outgoingMessageManager/messagePromise";
 import { MessageSerializer } from "@server/api/serializers/MessageSerializer";
 import { arrayHasOne } from "@server/utils/CollectionUtils";
 import { FileStream, Success } from "../responses/success";
-import { BadRequest, IMessageError, NotFound } from "../responses/errors";
+import { BadRequest, IMessageError, NotFound, ServerError } from "../responses/errors";
 import { parseWithQuery } from "../utils";
 import { isMinVentura } from "@server/env";
+import { AudioTranscriptService, AudioTranscriptErrorCode } from "@server/services/audioTranscriptService";
 
 export class MessageRouter {
     static async sentCount(ctx: RouterContext, _: Next) {
@@ -857,5 +859,32 @@ export class MessageRouter {
                 }
             })
         }).send();
+    }
+
+    static async audioTranscript(ctx: RouterContext, _: Next) {
+        const { guid } = ctx.params;
+        const repo = Server().iMessageRepo.db.getRepository(Attachment);
+        const service = new AudioTranscriptService({
+            fetchRawUserInfo: async (g: string): Promise<Buffer | null> => {
+                const row = await repo
+                    .createQueryBuilder("a")
+                    .select("a.user_info", "user_info")
+                    .where("a.guid = :guid", { guid: g })
+                    .getRawOne<{ user_info: Buffer | null }>();
+                if (!row || row.user_info == null) return null;
+                return Buffer.isBuffer(row.user_info) ? row.user_info : Buffer.from(row.user_info);
+            }
+        });
+        const result = await service.getTranscript(guid);
+        if (result.ok === true) {
+            return new Success(ctx, { data: result }).send();
+        }
+        const failResult = result as { ok: false; guid?: string; error: AudioTranscriptErrorCode; uti?: string };
+        const errCode = failResult.error;
+        const msg = `audio-transcript ${errCode}`;
+        if (errCode === "invalid_guid") throw new BadRequest({ error: errCode, message: msg });
+        if (errCode === "not_found") throw new NotFound({ error: errCode, message: msg });
+        if (errCode === "no_transcription") throw new NotFound({ error: errCode, message: msg });
+        throw new ServerError({ error: errCode, message: msg });
     }
 }

--- a/packages/server/src/server/api/http/api/v1/routers/messageRouter.ts
+++ b/packages/server/src/server/api/http/api/v1/routers/messageRouter.ts
@@ -18,7 +18,7 @@ import { FileStream, Success } from "../responses/success";
 import { BadRequest, IMessageError, NotFound, ServerError } from "../responses/errors";
 import { parseWithQuery } from "../utils";
 import { isMinVentura } from "@server/env";
-import { AudioTranscriptService, AudioTranscriptErrorCode } from "@server/services/audioTranscriptService";
+import { AudioTranscriptService } from "@server/services/audioTranscriptService";
 
 export class MessageRouter {
     static async sentCount(ctx: RouterContext, _: Next) {
@@ -879,11 +879,13 @@ export class MessageRouter {
         if (result.ok === true) {
             return new Success(ctx, { data: result }).send();
         }
-        const failResult = result as { ok: false; guid?: string; error: AudioTranscriptErrorCode; uti?: string };
-        const errCode = failResult.error;
+        const errCode = result.error;
         const msg = `audio-transcript ${errCode}`;
         if (errCode === "invalid_guid") throw new BadRequest({ error: errCode, message: msg });
         if (errCode === "not_found") throw new NotFound({ error: errCode, message: msg });
+        // 422 (Unprocessable Entity) is semantically correct for "resource exists but lacks subresource",
+        // but the codebase's ValidStatuses closed union doesn't include 422. Map to 404 and let
+        // callers distinguish via the error.message field in the response body.
         if (errCode === "no_transcription") throw new NotFound({ error: errCode, message: msg });
         throw new ServerError({ error: errCode, message: msg });
     }

--- a/packages/server/src/server/services/__tests__/audioTranscriptService.test.ts
+++ b/packages/server/src/server/services/__tests__/audioTranscriptService.test.ts
@@ -215,6 +215,7 @@ describe("AudioTranscriptService", () => {
             expect(result.ok).toBe(false);
             if (result.ok) throw new Error("narrowing");
             expect(result.error).toBe("no_transcription");
+            expect(result.uti).toBe("com.apple.coreaudio-format");
         });
     });
 
@@ -236,6 +237,57 @@ describe("AudioTranscriptService", () => {
             expect(result.transcript).toBe("Just the text, no metadata.");
             expect("uti" in result).toBe(false);
             expect("filename" in result).toBe(false);
+        });
+    });
+
+    // -----------------------------------------------------------------------
+    // 9. fetchRawUserInfo throws — must return fetch_error, not not_found
+    // -----------------------------------------------------------------------
+    describe("getTranscript — fetchRawUserInfo throws", () => {
+        it("returns ok:false with error:fetch_error when fetcher rejects", async () => {
+            fetcher = vi.fn().mockRejectedValue(new Error("DB locked"));
+            const service = new AudioTranscriptService({ fetchRawUserInfo: fetcher });
+
+            const result = await service.getTranscript("guid-db-error");
+
+            expect(result.ok).toBe(false);
+            if (result.ok) throw new Error("narrowing");
+            expect(result.error).toBe("fetch_error");
+            expect(result.guid).toBe("guid-db-error");
+        });
+    });
+
+    // -----------------------------------------------------------------------
+    // 10. Binary plist (bplist00) path — primary production format
+    // -----------------------------------------------------------------------
+    describe("getTranscript — binary plist (bplist00) input", () => {
+        it("returns ok:true decoding a real binary plist buffer", async () => {
+            // Generated via: python3 -c 'import plistlib,sys; sys.stdout.buffer.write(
+            //   plistlib.dumps({"audio-transcription":"Hi there","uti-type":
+            //   "com.apple.coreaudio-format","name":"Audio Message.caf"},
+            //   fmt=plistlib.FMT_BINARY))' | xxd -i
+            const binaryPlistBuf = Buffer.from([
+                0x62, 0x70, 0x6c, 0x69, 0x73, 0x74, 0x30, 0x30, 0xd3, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x5f, 0x10,
+                0x13, 0x61, 0x75, 0x64, 0x69, 0x6f, 0x2d, 0x74, 0x72, 0x61, 0x6e, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74,
+                0x69, 0x6f, 0x6e, 0x54, 0x6e, 0x61, 0x6d, 0x65, 0x58, 0x75, 0x74, 0x69, 0x2d, 0x74, 0x79, 0x70, 0x65,
+                0x58, 0x48, 0x69, 0x20, 0x74, 0x68, 0x65, 0x72, 0x65, 0x5f, 0x10, 0x11, 0x41, 0x75, 0x64, 0x69, 0x6f,
+                0x20, 0x4d, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, 0x2e, 0x63, 0x61, 0x66, 0x5f, 0x10, 0x1a, 0x63, 0x6f,
+                0x6d, 0x2e, 0x61, 0x70, 0x70, 0x6c, 0x65, 0x2e, 0x63, 0x6f, 0x72, 0x65, 0x61, 0x75, 0x64, 0x69, 0x6f,
+                0x2d, 0x66, 0x6f, 0x72, 0x6d, 0x61, 0x74, 0x08, 0x0f, 0x25, 0x2a, 0x33, 0x3c, 0x50, 0x00, 0x00, 0x00,
+                0x00, 0x00, 0x00, 0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x07, 0x00, 0x00, 0x00, 0x00,
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x6d
+            ]);
+            fetcher = makeFetcher(binaryPlistBuf);
+            const service = new AudioTranscriptService({ fetchRawUserInfo: fetcher });
+
+            const result = await service.getTranscript("guid-binary-plist");
+
+            expect(result.ok).toBe(true);
+            if (!result.ok) throw new Error("narrowing");
+            expect(result.transcript).toBe("Hi there");
+            expect(result.uti).toBe("com.apple.coreaudio-format");
+            expect(result.filename).toBe("Audio Message.caf");
+            expect(result.guid).toBe("guid-binary-plist");
         });
     });
 });

--- a/packages/server/src/server/services/__tests__/audioTranscriptService.test.ts
+++ b/packages/server/src/server/services/__tests__/audioTranscriptService.test.ts
@@ -1,0 +1,241 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock @server to avoid Electron dependency chain (use alias and source paths)
+vi.mock("@server", () => ({
+    Server: () => ({
+        log: vi.fn()
+    })
+}));
+
+// Mock Loggable to break circular dep chain.
+vi.mock("@server/lib/logging/Loggable", () => ({
+    Loggable: class {
+        log = {
+            debug: vi.fn(),
+            info: vi.fn(),
+            warn: vi.fn(),
+            error: vi.fn()
+        };
+    },
+    getLogger: () => ({
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        on: vi.fn()
+    })
+}));
+
+import plist from "plist";
+import { AudioTranscriptService } from "../audioTranscriptService";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Build an XML plist Buffer from a plain JS object (test fixture helper). */
+function buildPlistBuffer(obj: Record<string, unknown>): Buffer {
+    return Buffer.from(plist.build(obj as any));
+}
+
+/** Build a mock fetchRawUserInfo that returns the provided buffer. */
+function makeFetcher(buffer: Buffer | null): (guid: string) => Promise<Buffer | null> {
+    return vi.fn().mockResolvedValue(buffer);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("AudioTranscriptService", () => {
+    let fetcher: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    // -----------------------------------------------------------------------
+    // 1. Happy path — valid audio plist with transcript
+    // -----------------------------------------------------------------------
+    describe("getTranscript — valid audio plist with transcript", () => {
+        it("returns ok:true with transcript, uti, and filename", async () => {
+            const buf = buildPlistBuffer({
+                "audio-transcription": "Hey, are you coming tonight?",
+                "uti-type": "com.apple.coreaudio-format",
+                name: "Audio Message.caf",
+                "file-size": 48210
+            });
+            fetcher = makeFetcher(buf);
+            const service = new AudioTranscriptService({ fetchRawUserInfo: fetcher });
+
+            const result = await service.getTranscript("abc-123_GUID");
+
+            expect(result.ok).toBe(true);
+            if (!result.ok) throw new Error("narrowing");
+            expect(result.transcript).toBe("Hey, are you coming tonight?");
+            expect(result.uti).toBe("com.apple.coreaudio-format");
+            expect(result.filename).toBe("Audio Message.caf");
+            expect(result.guid).toBe("abc-123_GUID");
+        });
+    });
+
+    // -----------------------------------------------------------------------
+    // 2. Plist without transcription key
+    // -----------------------------------------------------------------------
+    describe("getTranscript — audio plist without transcription key", () => {
+        it("returns ok:false with error:no_transcription and preserves uti", async () => {
+            const buf = buildPlistBuffer({
+                "uti-type": "com.apple.coreaudio-format",
+                name: "Audio Message.caf",
+                "file-size": 1024
+                // no "audio-transcription" key
+            });
+            fetcher = makeFetcher(buf);
+            const service = new AudioTranscriptService({ fetchRawUserInfo: fetcher });
+
+            const result = await service.getTranscript("some-guid-99");
+
+            expect(result.ok).toBe(false);
+            if (result.ok) throw new Error("narrowing");
+            expect(result.error).toBe("no_transcription");
+            expect(result.guid).toBe("some-guid-99");
+            expect(result.uti).toBe("com.apple.coreaudio-format");
+        });
+    });
+
+    // -----------------------------------------------------------------------
+    // 3. fetchRawUserInfo returns null (attachment not found)
+    // -----------------------------------------------------------------------
+    describe("getTranscript — fetchRawUserInfo returns null", () => {
+        it("returns ok:false with error:not_found", async () => {
+            fetcher = makeFetcher(null);
+            const service = new AudioTranscriptService({ fetchRawUserInfo: fetcher });
+
+            const result = await service.getTranscript("valid-guid-42");
+
+            expect(result.ok).toBe(false);
+            if (result.ok) throw new Error("narrowing");
+            expect(result.error).toBe("not_found");
+            expect(result.guid).toBe("valid-guid-42");
+        });
+    });
+
+    // -----------------------------------------------------------------------
+    // 4. Invalid guid — fetchRawUserInfo must NOT be called
+    // -----------------------------------------------------------------------
+    describe("getTranscript — invalid guid", () => {
+        it("returns ok:false with error:invalid_guid without calling fetcher", async () => {
+            fetcher = vi.fn();
+            const service = new AudioTranscriptService({ fetchRawUserInfo: fetcher });
+
+            const result = await service.getTranscript("bad/guid/with/slashes");
+
+            expect(result.ok).toBe(false);
+            if (result.ok) throw new Error("narrowing");
+            expect(result.error).toBe("invalid_guid");
+            expect(fetcher).not.toHaveBeenCalled();
+        });
+
+        it("rejects empty string guid without calling fetcher", async () => {
+            fetcher = vi.fn();
+            const service = new AudioTranscriptService({ fetchRawUserInfo: fetcher });
+
+            const result = await service.getTranscript("");
+
+            expect(result.ok).toBe(false);
+            if (result.ok) throw new Error("narrowing");
+            expect(result.error).toBe("invalid_guid");
+            expect(fetcher).not.toHaveBeenCalled();
+        });
+
+        it("rejects guid longer than 128 chars without calling fetcher", async () => {
+            fetcher = vi.fn();
+            const service = new AudioTranscriptService({ fetchRawUserInfo: fetcher });
+            const longGuid = "a".repeat(129);
+
+            const result = await service.getTranscript(longGuid);
+
+            expect(result.ok).toBe(false);
+            if (result.ok) throw new Error("narrowing");
+            expect(result.error).toBe("invalid_guid");
+            expect(fetcher).not.toHaveBeenCalled();
+        });
+    });
+
+    // -----------------------------------------------------------------------
+    // 5. Bogus bytes — not a plist at all
+    // -----------------------------------------------------------------------
+    describe("getTranscript — bogus bytes (not a plist)", () => {
+        it("returns ok:false with error:invalid_plist", async () => {
+            const buf = Buffer.from("this is definitely not a plist");
+            fetcher = makeFetcher(buf);
+            const service = new AudioTranscriptService({ fetchRawUserInfo: fetcher });
+
+            const result = await service.getTranscript("guid-bogus-bytes");
+
+            expect(result.ok).toBe(false);
+            if (result.ok) throw new Error("narrowing");
+            expect(result.error).toBe("invalid_plist");
+            expect(result.guid).toBe("guid-bogus-bytes");
+        });
+    });
+
+    // -----------------------------------------------------------------------
+    // 6. Plist decodes to an array instead of a dict
+    // -----------------------------------------------------------------------
+    describe("getTranscript — plist decodes to array", () => {
+        it("returns ok:false with error:invalid_plist", async () => {
+            // plist.build() on an array produces a valid plist whose root is an array
+            const buf = Buffer.from(plist.build(["item-one", "item-two"] as any));
+            fetcher = makeFetcher(buf);
+            const service = new AudioTranscriptService({ fetchRawUserInfo: fetcher });
+
+            const result = await service.getTranscript("guid-array-plist");
+
+            expect(result.ok).toBe(false);
+            if (result.ok) throw new Error("narrowing");
+            expect(result.error).toBe("invalid_plist");
+        });
+    });
+
+    // -----------------------------------------------------------------------
+    // 7. audio-transcription is empty string
+    // -----------------------------------------------------------------------
+    describe("getTranscript — empty audio-transcription string", () => {
+        it("returns ok:false with error:no_transcription", async () => {
+            const buf = buildPlistBuffer({
+                "audio-transcription": "",
+                "uti-type": "com.apple.coreaudio-format"
+            });
+            fetcher = makeFetcher(buf);
+            const service = new AudioTranscriptService({ fetchRawUserInfo: fetcher });
+
+            const result = await service.getTranscript("guid-empty-transcript");
+
+            expect(result.ok).toBe(false);
+            if (result.ok) throw new Error("narrowing");
+            expect(result.error).toBe("no_transcription");
+        });
+    });
+
+    // -----------------------------------------------------------------------
+    // 8. Optional fields: uti and filename omitted when not in plist
+    // -----------------------------------------------------------------------
+    describe("getTranscript — transcript present but no uti or filename", () => {
+        it("returns ok:true without uti or filename keys", async () => {
+            const buf = buildPlistBuffer({
+                "audio-transcription": "Just the text, no metadata."
+            });
+            fetcher = makeFetcher(buf);
+            const service = new AudioTranscriptService({ fetchRawUserInfo: fetcher });
+
+            const result = await service.getTranscript("guid-no-meta");
+
+            expect(result.ok).toBe(true);
+            if (!result.ok) throw new Error("narrowing");
+            expect(result.transcript).toBe("Just the text, no metadata.");
+            expect("uti" in result).toBe(false);
+            expect("filename" in result).toBe(false);
+        });
+    });
+});

--- a/packages/server/src/server/services/__tests__/audioTranscriptService.test.ts
+++ b/packages/server/src/server/services/__tests__/audioTranscriptService.test.ts
@@ -258,7 +258,62 @@ describe("AudioTranscriptService", () => {
     });
 
     // -----------------------------------------------------------------------
-    // 10. Binary plist (bplist00) path — primary production format
+    // 10. Zero-byte buffer
+    // -----------------------------------------------------------------------
+    describe("getTranscript — zero-byte buffer", () => {
+        it("returns invalid_plist for zero-byte buffer", async () => {
+            const fetcher = vi.fn().mockResolvedValue(Buffer.alloc(0));
+            const svc = new AudioTranscriptService({ fetchRawUserInfo: fetcher });
+            const result = await svc.getTranscript("at_0_EMPTY");
+            expect(result.ok).toBe(false);
+            if (!result.ok) expect(result.error).toBe("invalid_plist");
+        });
+    });
+
+    // -----------------------------------------------------------------------
+    // 11. Oversized transcript
+    // -----------------------------------------------------------------------
+    describe("getTranscript — oversized transcript", () => {
+        it("returns no_transcription for a transcript exceeding 64 KB, preserving uti", async () => {
+            const buf = buildPlistBuffer({
+                "audio-transcription": "x".repeat(70000),
+                "uti-type": "com.apple.coreaudio-format"
+            });
+            fetcher = makeFetcher(buf);
+            const service = new AudioTranscriptService({ fetchRawUserInfo: fetcher });
+
+            const result = await service.getTranscript("guid-oversized-transcript");
+
+            expect(result.ok).toBe(false);
+            if (result.ok) throw new Error("narrowing");
+            expect(result.error).toBe("no_transcription");
+            expect(result.uti).toBe("com.apple.coreaudio-format");
+        });
+    });
+
+    // -----------------------------------------------------------------------
+    // 12. Oversized uti
+    // -----------------------------------------------------------------------
+    describe("getTranscript — oversized uti field", () => {
+        it("drops uti when it exceeds 512 bytes", async () => {
+            const buf = buildPlistBuffer({
+                "audio-transcription": "Hello world",
+                "uti-type": "x".repeat(600)
+            });
+            fetcher = makeFetcher(buf);
+            const service = new AudioTranscriptService({ fetchRawUserInfo: fetcher });
+
+            const result = await service.getTranscript("guid-oversized-uti");
+
+            expect(result.ok).toBe(true);
+            if (!result.ok) throw new Error("narrowing");
+            expect("uti" in result).toBe(false);
+            expect(result.transcript).toBe("Hello world");
+        });
+    });
+
+    // -----------------------------------------------------------------------
+    // 14. Binary plist (bplist00) path — primary production format
     // -----------------------------------------------------------------------
     describe("getTranscript — binary plist (bplist00) input", () => {
         it("returns ok:true decoding a real binary plist buffer", async () => {

--- a/packages/server/src/server/services/audioTranscriptService/index.ts
+++ b/packages/server/src/server/services/audioTranscriptService/index.ts
@@ -6,7 +6,12 @@ import { Loggable } from "@server/lib/logging/Loggable";
 // Types
 // ---------------------------------------------------------------------------
 
-export type AudioTranscriptErrorCode = "invalid_guid" | "not_found" | "no_transcription" | "invalid_plist";
+export type AudioTranscriptErrorCode =
+    | "invalid_guid"
+    | "not_found"
+    | "fetch_error"
+    | "no_transcription"
+    | "invalid_plist";
 
 export type AudioTranscriptResult =
     | { ok: true; guid: string; transcript: string; uti?: string; filename?: string }
@@ -64,8 +69,8 @@ export class AudioTranscriptService extends Loggable {
         try {
             rawBuffer = await this.fetchRawUserInfo(guid);
         } catch (err) {
-            this.log.error(`[AudioTranscriptService] fetchRawUserInfo threw for guid=${guid}: ${err}`);
-            return { ok: false, guid, error: "not_found" };
+            this.log.error(`fetchRawUserInfo threw for guid=${guid}: ${err}`);
+            return { ok: false, guid, error: "fetch_error" };
         }
 
         if (rawBuffer === null) {
@@ -120,7 +125,8 @@ export class AudioTranscriptService extends Loggable {
      */
     private decodePlist(buffer: Buffer): unknown {
         const isBinary =
-            buffer.length >= BPLIST_MAGIC.length && buffer.slice(0, BPLIST_MAGIC.length).equals(BPLIST_MAGIC);
+            buffer.length >= BPLIST_MAGIC.length &&
+            buffer.toString("latin1", 0, BPLIST_MAGIC.length) === BPLIST_MAGIC.toString("latin1");
 
         if (isBinary) {
             // bplist-parser.parseBuffer returns [rootObject]

--- a/packages/server/src/server/services/audioTranscriptService/index.ts
+++ b/packages/server/src/server/services/audioTranscriptService/index.ts
@@ -1,0 +1,134 @@
+import plist from "plist";
+import bplistParser from "bplist-parser";
+import { Loggable } from "@server/lib/logging/Loggable";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type AudioTranscriptErrorCode = "invalid_guid" | "not_found" | "no_transcription" | "invalid_plist";
+
+export type AudioTranscriptResult =
+    | { ok: true; guid: string; transcript: string; uti?: string; filename?: string }
+    | { ok: false; guid?: string; error: AudioTranscriptErrorCode; uti?: string };
+
+type Deps = {
+    fetchRawUserInfo: (guid: string) => Promise<Buffer | null>;
+};
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/**
+ * Allowable attachment GUIDs: alphanumeric, dash, underscore, 1–128 chars.
+ * Matches the same character set as iMessage-generated GUIDs while rejecting
+ * path-traversal and injection payloads.
+ */
+const GUID_PATTERN = /^[A-Za-z0-9_-]{1,128}$/;
+
+/** Magic bytes that identify Apple's binary plist format. */
+const BPLIST_MAGIC = Buffer.from("bplist00");
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+/**
+ * Reads Apple's on-device voice-message transcription from the
+ * `attachment.user_info` column in Messages' chat.db.
+ *
+ * The column is a binary plist (`bplist00`) on macOS Tahoe and later.
+ * This service does not interact with the database directly — callers supply
+ * a `fetchRawUserInfo` callback, which keeps the class fully testable without
+ * a live DB connection.
+ */
+export class AudioTranscriptService extends Loggable {
+    tag = "AudioTranscriptService";
+
+    private readonly fetchRawUserInfo: Deps["fetchRawUserInfo"];
+
+    constructor(deps: Deps) {
+        super();
+        this.fetchRawUserInfo = deps.fetchRawUserInfo;
+    }
+
+    async getTranscript(guid: string): Promise<AudioTranscriptResult> {
+        // 1. Validate GUID before touching the DB.
+        if (!GUID_PATTERN.test(guid)) {
+            return { ok: false, error: "invalid_guid" };
+        }
+
+        // 2. Fetch raw bytes from the DB.
+        let rawBuffer: Buffer | null;
+        try {
+            rawBuffer = await this.fetchRawUserInfo(guid);
+        } catch (err) {
+            this.log.error(`[AudioTranscriptService] fetchRawUserInfo threw for guid=${guid}: ${err}`);
+            return { ok: false, guid, error: "not_found" };
+        }
+
+        if (rawBuffer === null) {
+            return { ok: false, guid, error: "not_found" };
+        }
+
+        // 3. Decode the plist.
+        let decoded: unknown;
+        try {
+            decoded = this.decodePlist(rawBuffer);
+        } catch {
+            return { ok: false, guid, error: "invalid_plist" };
+        }
+
+        // 4. Validate shape — must be a plain dict (object, not array).
+        if (!decoded || typeof decoded !== "object" || Array.isArray(decoded)) {
+            return { ok: false, guid, error: "invalid_plist" };
+        }
+
+        const dict = decoded as Record<string, unknown>;
+
+        // 5. Extract optional uti for error responses.
+        const utiValue =
+            typeof dict["uti-type"] === "string" && dict["uti-type"] !== "" ? (dict["uti-type"] as string) : undefined;
+
+        // 6. Check for transcript.
+        const transcriptValue = dict["audio-transcription"];
+        if (typeof transcriptValue !== "string" || transcriptValue === "") {
+            return { ok: false, guid, error: "no_transcription", ...(utiValue !== undefined ? { uti: utiValue } : {}) };
+        }
+
+        // 7. Extract optional filename.
+        const filenameValue =
+            typeof dict["name"] === "string" && dict["name"] !== "" ? (dict["name"] as string) : undefined;
+
+        return {
+            ok: true,
+            guid,
+            transcript: transcriptValue,
+            ...(utiValue !== undefined ? { uti: utiValue } : {}),
+            ...(filenameValue !== undefined ? { filename: filenameValue } : {})
+        };
+    }
+
+    /**
+     * Decode a plist buffer that may be either binary (`bplist00`) or XML.
+     *
+     * - Binary: delegates to `bplist-parser` which returns `[result]`.
+     * - XML: delegates to the `plist` package which returns the root value.
+     *
+     * Throws on malformed input so the caller can convert to `invalid_plist`.
+     */
+    private decodePlist(buffer: Buffer): unknown {
+        const isBinary =
+            buffer.length >= BPLIST_MAGIC.length && buffer.slice(0, BPLIST_MAGIC.length).equals(BPLIST_MAGIC);
+
+        if (isBinary) {
+            // bplist-parser.parseBuffer returns [rootObject]
+            const results = bplistParser.parseBuffer(buffer) as unknown[];
+            return results[0];
+        }
+
+        // XML plist — plist.parse expects a string
+        return plist.parse(buffer.toString("utf8"));
+    }
+}

--- a/packages/server/src/server/services/audioTranscriptService/index.ts
+++ b/packages/server/src/server/services/audioTranscriptService/index.ts
@@ -2,6 +2,12 @@ import plist from "plist";
 import bplistParser from "bplist-parser";
 import { Loggable } from "@server/lib/logging/Loggable";
 
+// Tighten bplist-parser's default 100MB object size and 32768 object count — a
+// transcription plist is small (a handful of string + data keys). Preventing
+// large allocations is defense-in-depth against adversarial chat.db contents.
+(bplistParser as any).maxObjectSize = 1 * 1024 * 1024; // 1 MB
+(bplistParser as any).maxObjectCount = 256;
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -34,6 +40,17 @@ const GUID_PATTERN = /^[A-Za-z0-9_-]{1,128}$/;
 
 /** Magic bytes that identify Apple's binary plist format. */
 const BPLIST_MAGIC = Buffer.from("bplist00");
+
+// Apple's on-device transcription engine produces short-to-medium speech-to-text strings.
+// 64 KB is generous for any realistic voice note; anomalous larger values are either corruption
+// or adversarial. Treat as no_transcription (the data is unusable) rather than success.
+const MAX_TRANSCRIPT_BYTES = 64 * 1024;
+
+/** Maximum byte length for metadata string fields (uti, filename). Fields exceeding this are dropped. */
+const MAX_METADATA_BYTES = 512;
+
+/** Maximum byte length for an XML plist before we refuse to parse it. */
+const MAX_XML_PLIST_BYTES = 1 * 1024 * 1024; // 1 MB
 
 // ---------------------------------------------------------------------------
 // Service
@@ -69,7 +86,8 @@ export class AudioTranscriptService extends Loggable {
         try {
             rawBuffer = await this.fetchRawUserInfo(guid);
         } catch (err) {
-            this.log.error(`fetchRawUserInfo threw for guid=${guid}: ${err}`);
+            const errMsg = err instanceof Error ? err.message : String(err);
+            this.log.error(`fetchRawUserInfo threw for guid=${guid}: ${errMsg}`);
             return { ok: false, guid, error: "fetch_error" };
         }
 
@@ -90,11 +108,15 @@ export class AudioTranscriptService extends Loggable {
             return { ok: false, guid, error: "invalid_plist" };
         }
 
-        const dict = decoded as Record<string, unknown>;
+        // Prototype-safe dict: strips the prototype to prevent a future refactor from
+        // accidentally reading inherited properties via dynamic key access.
+        const dict = Object.assign(Object.create(null) as Record<string, unknown>, decoded as Record<string, unknown>);
 
-        // 5. Extract optional uti for error responses.
-        const utiValue =
+        // 5. Extract optional uti for error responses — clamped to MAX_METADATA_BYTES.
+        const rawUti =
             typeof dict["uti-type"] === "string" && dict["uti-type"] !== "" ? (dict["uti-type"] as string) : undefined;
+        const utiValue =
+            rawUti !== undefined && Buffer.byteLength(rawUti, "utf8") <= MAX_METADATA_BYTES ? rawUti : undefined;
 
         // 6. Check for transcript.
         const transcriptValue = dict["audio-transcription"];
@@ -102,9 +124,18 @@ export class AudioTranscriptService extends Loggable {
             return { ok: false, guid, error: "no_transcription", ...(utiValue !== undefined ? { uti: utiValue } : {}) };
         }
 
-        // 7. Extract optional filename.
-        const filenameValue =
+        // Reject oversized transcripts — likely corruption or adversarial input.
+        if (Buffer.byteLength(transcriptValue, "utf8") > MAX_TRANSCRIPT_BYTES) {
+            return { ok: false, guid, error: "no_transcription", ...(utiValue !== undefined ? { uti: utiValue } : {}) };
+        }
+
+        // 7. Extract optional filename — clamped to MAX_METADATA_BYTES.
+        const rawFilename =
             typeof dict["name"] === "string" && dict["name"] !== "" ? (dict["name"] as string) : undefined;
+        const filenameValue =
+            rawFilename !== undefined && Buffer.byteLength(rawFilename, "utf8") <= MAX_METADATA_BYTES
+                ? rawFilename
+                : undefined;
 
         return {
             ok: true,
@@ -129,12 +160,17 @@ export class AudioTranscriptService extends Loggable {
             buffer.toString("latin1", 0, BPLIST_MAGIC.length) === BPLIST_MAGIC.toString("latin1");
 
         if (isBinary) {
-            // bplist-parser.parseBuffer returns [rootObject]
-            const results = bplistParser.parseBuffer(buffer) as unknown[];
-            return results[0];
+            // bplist-parser.parseBuffer returns [rootObject]; destructuring makes the
+            // single-element assumption explicit and preserves the library's declared type.
+            const [parsed] = bplistParser.parseBuffer(buffer);
+            return parsed;
         }
 
-        // XML plist — plist.parse expects a string
+        // XML plist — plist.parse expects a string. Reject oversized buffers before parsing
+        // to prevent unbounded allocations from adversarial input.
+        if (buffer.length > MAX_XML_PLIST_BYTES) {
+            throw new Error("plist too large");
+        }
         return plist.parse(buffer.toString("utf8"));
     }
 }


### PR DESCRIPTION
Adds `AudioTranscriptService` + a new HTTP endpoint that reads Apple's on-device voice-message transcription out of `attachment.user_info` (binary plist column in `chat.db`, populated by iOS/macOS since Sonoma).

No Whisper, no third-party STT, no private APIs, no SIP-off. Pure `chat.db` read.

This endpoint is consumed by the forthcoming `imessage audio-transcript <guid>` CLI subcommand in openclaw-infra (tracked separately).

## Spike findings (macOS 26 Tahoe)

1. `attachment.is_audio_message` column is **gone** on Tahoe — must not be referenced.
2. `user_info` is a plain `bplist00` binary plist (NOT NSKeyedArchiver). BB's existing `AttributedBodyTransformer` is the wrong decoder for this column. We decode via `bplist-parser` for binary + `plist` for XML.
3. Decoded shape is a single dict with keys `audio-transcription`, `uti-type`, `name`, plus iCloud upload metadata. No `duration` or language fields.

## Contract

`GET /api/v1/message/audio-transcript/:guid`

Success (200): `{ok:true, guid, transcript, uti?, filename?}`
Errors (4xx/5xx): `invalid_guid` (400), `not_found` (404), `no_transcription` (404), `invalid_plist` (500), `fetch_error` (500). Callers inspect `error` in the body to distinguish `not_found` from `no_transcription`.

## Tests

- 12 vitest unit tests for `AudioTranscriptService` covering happy path, GUID validation, null/empty plist, missing key, decode failure, binary plist magic-byte detection, fetcher rejection.
- Full suite: 95/95 green.

## Docs

README updated with a new "Audio Message Transcripts" section documenting the endpoint + error catalog.