### PR TITLE
chore: build UI before packaging (#42)

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -15,7 +15,7 @@
         "test": "vitest run",
         "test:watch": "vitest",
         "test:coverage": "vitest run --coverage",
-        "dist": "npm run build && electron-builder build --mac --publish never --config ./scripts/electron-builder-config.js",
+        "dist": "(cd ../.. && npm run build-ui) && npm run build && electron-builder build --mac --publish never --config ./scripts/electron-builder-config.js",
         "release": "npm run build && electron-builder build --mac --publish always --config ./scripts/electron-builder-config.js",
         "rebuild": "electron-rebuild -f better-sqlite3 node-mac-contacts node-mac-permissions",
         "postinstall": "electron-rebuild install-app-deps && npm run rebuild"

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -15,7 +15,8 @@
         "test": "vitest run",
         "test:watch": "vitest",
         "test:coverage": "vitest run --coverage",
-        "dist": "(cd ../.. && npm run build-ui) && npm run build && electron-builder build --mac --publish never --config ./scripts/electron-builder-config.js",
+        "predist": "cd ../.. && npm run build-ui",
+        "dist": "npm run build && electron-builder build --mac --publish never --config ./scripts/electron-builder-config.js",
         "release": "npm run build && electron-builder build --mac --publish always --config ./scripts/electron-builder-config.js",
         "rebuild": "electron-rebuild -f better-sqlite3 node-mac-contacts node-mac-permissions",
         "postinstall": "electron-rebuild install-app-deps && npm run rebuild"


### PR DESCRIPTION
Fixes #42.

## Problem

Running `npm run dist` directly from `packages/server` skips the React UI build, so the packaged Electron app ships without static assets and shows a blank window.

- Server-level `build` script is webpack-only (main-process bundle).
- Server-level `dist` was `npm run build && electron-builder ...` — UI never built.
- Root `build` chains `build-ui` then `build-server` correctly, but only the root invocation path worked.

## Fix (minimum diff)

Prepend a subshell call to root `build-ui` in the server `dist` script:

```diff
-"dist": "npm run build && electron-builder build --mac --publish never --config ./scripts/electron-builder-config.js",
+"dist": "(cd ../.. && npm run build-ui) && npm run build && electron-builder build --mac --publish never --config ./scripts/electron-builder-config.js",
```

### Why not call root `npm run build` directly (Option 1 as literally stated)?

Root `build` → `build-server` → `cd packages/server && npm run dist` → (new) root `build` → infinite loop. Invoking the atomic `build-ui` script avoids recursion while still ensuring UI assets land in `packages/server/dist/static` before `electron-builder` packages them.

### Subshell (parentheses) vs. plain `cd`

The parens isolate `cd ../..` so the subsequent `npm run build && electron-builder` still resolves its relative paths (`./scripts/webpack.main.prod.config.js`, `./scripts/electron-builder-config.js`) from `packages/server`.

## Side effect on existing root build

When invoked via the root `npm run build` (CI / release path), `build-ui` now runs twice — once from root, once from the nested server `dist`. React build is idempotent (~30s) and completes before electron-builder (~5min), so the cost is minor and the outcome identical. Direct server `dist` invocation now produces a working app. The `release` script at the server level is unchanged (still used by the root `release` pipeline which already handles UI).

## Verification

- JSON validity confirmed (`json.load` OK).
- Shell chain parses: `(cd ../.. && pwd) && pwd` from `packages/server` returns to `packages/server` correctly (subshell scoping).
- Root `build-ui` script confirmed reachable from server dir via `cd ../..`.
- Did **not** run full `electron-builder` packaging (5+ min, would produce release artifacts and attempt codesigning in a worktree). CI on this PR exercises `nix flake check` / standard checks; a release smoke test is out of scope for a one-line scripts edit.

## Risk

Low. Only affects `packages/server/package.json` `dist` script. Root build path is unchanged structurally — just an extra idempotent UI rebuild. `release` script untouched.