### PR TITLE
perf(ax-helper): skipRoot + traversal tests (closes #58, #59)

### DIFF
--- a/packages/server/appResources/ax-helper/Package.swift
+++ b/packages/server/appResources/ax-helper/Package.swift
@@ -22,7 +22,13 @@ let package = Package(
         .testTarget(
             name: "AXHelperTests",
             dependencies: [
-                .product(name: "Testing", package: "swift-testing")
+                .product(name: "Testing", package: "swift-testing"),
+                // Depend on the executable target so unit tests can
+                // `@testable import ax_helper` and exercise internal helpers
+                // (e.g. `AXHelper.walkLast`) directly in-process. Integration
+                // tests in CLITests.swift still fork the built binary — this
+                // dependency does not affect them.
+                .target(name: "ax-helper")
             ],
             path: "Tests/AXHelperTests",
             swiftSettings: [

--- a/packages/server/appResources/ax-helper/Sources/AXHelper.swift
+++ b/packages/server/appResources/ax-helper/Sources/AXHelper.swift
@@ -117,6 +117,10 @@ enum AXHelper {
     /// traversal order, depth bounds, predicate semantics, and `skipRoot` behavior
     /// without needing to construct AX tree fixtures.
     ///
+    /// **Internal: exposed module-wide for `@testable import ax_helper` only.**
+    /// Production code should use `findLastDescendant(_:matching:maxDepth:skipRoot:)`;
+    /// this helper is a testing surface, not a stable API.
+    ///
     /// Semantics:
     /// - Visits `root` first (if `skipRoot == false`), then children in order,
     ///   recursively. Later matches overwrite earlier ones, so the result is the
@@ -129,8 +133,8 @@ enum AXHelper {
         root: T,
         children: (T) -> [T],
         matches: (T) -> Bool,
-        maxDepth: Int,
-        skipRoot: Bool
+        maxDepth: Int = 25,
+        skipRoot: Bool = false
     ) -> T? {
         return walkLastRecursive(
             node: root,

--- a/packages/server/appResources/ax-helper/Sources/AXHelper.swift
+++ b/packages/server/appResources/ax-helper/Sources/AXHelper.swift
@@ -72,41 +72,99 @@ enum AXHelper {
     /// - Parameter maxDepth: Maximum number of edges from `element` to any visited node.
     ///   `element` itself is at depth 0. `maxDepth: 25` visits up to 25 edges below
     ///   the root, which is safe for Messages.app's window-to-bubble depth.
+    /// - Parameter skipRoot: When true, `matching` is not evaluated on `element` itself —
+    ///   only on its descendants. Callers that know the root is a container (window, app,
+    ///   menu bar) that cannot possibly match their predicate should pass `true` to avoid
+    ///   one wasted predicate evaluation and any attribute fetches it triggers. Defaults
+    ///   to `false` to preserve the original semantics (root-inclusive).
     static func findLastDescendant(
         _ element: AXUIElement,
         matching: (AXUIElement) -> Bool,
-        maxDepth: Int = 25
+        maxDepth: Int = 25,
+        skipRoot: Bool = false
     ) -> AXUIElement? {
-        return findLastDescendant(element, matching: matching, depth: 0, maxDepth: maxDepth)
+        return walkLast(
+            root: element,
+            children: { attribute($0, kAXChildrenAttribute) as? [AXUIElement] ?? [] },
+            matches: matching,
+            maxDepth: maxDepth,
+            skipRoot: skipRoot
+        )
     }
 
     /// Messages.app-specific: find the last `AXGroup` with identifier `"Sticker"`
     /// in the subtree. This is the stable identifier for an iMessage bubble on
     /// Tahoe and later; the last match in tree order is the newest message.
     ///
-    /// - Parameter maxDepth: See `findLastDescendant(_:matching:maxDepth:)`.
+    /// - Parameter maxDepth: See `findLastDescendant(_:matching:maxDepth:skipRoot:)`.
     ///   Default 25 suits Messages.app's typical tree depth.
-    static func findLastStickerGroup(in element: AXUIElement, maxDepth: Int = 25) -> AXUIElement? {
+    /// - Parameter skipRoot: Forwarded to `findLastDescendant`. Typical callers pass the
+    ///   focused window or an app element as `element`, neither of which can match the
+    ///   Sticker predicate — passing `true` skips one predicate evaluation per call.
+    static func findLastStickerGroup(in element: AXUIElement, maxDepth: Int = 25, skipRoot: Bool = false) -> AXUIElement? {
         return findLastDescendant(element, matching: { candidate in
             let role = attribute(candidate, kAXRoleAttribute) as? String ?? ""
             let ident = attribute(candidate, kAXIdentifierAttribute) as? String ?? ""
             return role == "AXGroup" && ident == "Sticker"
-        }, maxDepth: maxDepth)
+        }, maxDepth: maxDepth, skipRoot: skipRoot)
+    }
+
+    // MARK: - Pure traversal helper (testable)
+
+    /// Pure, generic version of `findLastDescendant` with the AX dependency factored
+    /// out via a `children` closure. The AXUIElement-facing API delegates here; tests
+    /// exercise this directly with plain Swift values (e.g. a struct tree) to verify
+    /// traversal order, depth bounds, predicate semantics, and `skipRoot` behavior
+    /// without needing to construct AX tree fixtures.
+    ///
+    /// Semantics:
+    /// - Visits `root` first (if `skipRoot == false`), then children in order,
+    ///   recursively. Later matches overwrite earlier ones, so the result is the
+    ///   last match in DFS tree order.
+    /// - `maxDepth` is the maximum number of edges from `root`. `root` itself is at
+    ///   depth 0; children are at depth 1; etc. Nodes at or beyond `maxDepth` edges
+    ///   are not visited.
+    /// - Returns `nil` if no visited node matches.
+    static func walkLast<T>(
+        root: T,
+        children: (T) -> [T],
+        matches: (T) -> Bool,
+        maxDepth: Int,
+        skipRoot: Bool
+    ) -> T? {
+        return walkLastRecursive(
+            node: root,
+            children: children,
+            matches: matches,
+            depth: 0,
+            maxDepth: maxDepth,
+            skipRoot: skipRoot
+        )
     }
 
     // MARK: - Private
 
-    private static func findLastDescendant(
-        _ element: AXUIElement,
-        matching: (AXUIElement) -> Bool,
+    private static func walkLastRecursive<T>(
+        node: T,
+        children: (T) -> [T],
+        matches: (T) -> Bool,
         depth: Int,
-        maxDepth: Int
-    ) -> AXUIElement? {
+        maxDepth: Int,
+        skipRoot: Bool
+    ) -> T? {
         guard depth < maxDepth else { return nil }
-        var best: AXUIElement? = matching(element) ? element : nil
-        let kids = attribute(element, kAXChildrenAttribute) as? [AXUIElement] ?? []
-        for k in kids {
-            if let found = findLastDescendant(k, matching: matching, depth: depth + 1, maxDepth: maxDepth) {
+        // Skip root-level predicate evaluation when requested. Children are still
+        // walked normally — skipRoot is scoped to the current call's root only.
+        var best: T? = (skipRoot && depth == 0) ? nil : (matches(node) ? node : nil)
+        for k in children(node) {
+            if let found = walkLastRecursive(
+                node: k,
+                children: children,
+                matches: matches,
+                depth: depth + 1,
+                maxDepth: maxDepth,
+                skipRoot: false  // only the original root is skippable
+            ) {
                 best = found
             }
         }

--- a/packages/server/appResources/ax-helper/Sources/main.swift
+++ b/packages/server/appResources/ax-helper/Sources/main.swift
@@ -114,7 +114,9 @@ case "tapback":
         // (compile-time warning), so compare CFTypeIDs explicitly and fall
         // through to the windows fallback if the type is wrong.
         if CFGetTypeID(focusedAny as CFTypeRef) == AXUIElementGetTypeID() {
-            target = AXHelper.findLastStickerGroup(in: focusedAny as! AXUIElement)
+            // skipRoot: the focused window itself is an AXWindow, never an
+            // AXGroup id='Sticker'. Saves one predicate + two attribute fetches.
+            target = AXHelper.findLastStickerGroup(in: focusedAny as! AXUIElement, skipRoot: true)
         } else {
             writeError("kAXFocusedWindowAttribute returned non-AXUIElement type; falling back to window iteration")
         }
@@ -125,7 +127,9 @@ case "tapback":
         // overwrite `target` with a newer message from a different window,
         // losing the focused-window bias we intend to approximate here.
         for w in windows {
-            if let m = AXHelper.findLastStickerGroup(in: w) {
+            // skipRoot: each element here is an AXWindow from kAXWindowsAttribute;
+            // it cannot match the AXGroup id='Sticker' predicate.
+            if let m = AXHelper.findLastStickerGroup(in: w, skipRoot: true) {
                 target = m
                 break
             }

--- a/packages/server/appResources/ax-helper/Tests/AXHelperTests/FindLastDescendantTests.swift
+++ b/packages/server/appResources/ax-helper/Tests/AXHelperTests/FindLastDescendantTests.swift
@@ -223,8 +223,8 @@ struct FindLastDescendantTests {
         #expect(result == nil)
     }
 
-    @Test("skipRoot=true still walks children and returns descendant match")
-    func skipRootTrueStillWalksChildren() {
+    @Test("skipRoot=true still walks children and returns descendant match with shared id")
+    func skipRootTrueStillWalksChildrenSharedId() {
         // Root (id=100) would match but is skipped; descendant (id=100 also)
         // IS returned because skipRoot only applies to the entry-level root.
         let tree = TestNode(100, [
@@ -239,18 +239,21 @@ struct FindLastDescendantTests {
             skipRoot: true
         )
         #expect(result?.id == 100)
-        // To be sure this isn't the root being returned by accident, use
-        // identity on the nested node: rebuild with distinct markers.
-        let sentinel = TestNode(999)
-        let tree2 = TestNode(100, [TestNode(2), TestNode(3, [sentinel])])
-        let result2 = AXHelper.walkLast(
-            root: tree2,
+    }
+
+    @Test("skipRoot=true returns distinct descendant, not the root, when both could match")
+    func skipRootTrueReturnsDescendantNotRoot() {
+        // Uses distinct ids to prove the returned node is actually the nested
+        // one rather than the root being returned by accident.
+        let tree = TestNode(100, [TestNode(2), TestNode(3, [TestNode(999)])])
+        let result = AXHelper.walkLast(
+            root: tree,
             children: kids,
             matches: { $0.id == 999 || $0.id == 100 },
             maxDepth: 10,
             skipRoot: true
         )
-        #expect(result2?.id == 999)
+        #expect(result?.id == 999)
     }
 
     @Test("skipRoot does not cascade into descendant recursion")
@@ -286,7 +289,7 @@ struct FindLastDescendantTests {
     }
 
     @Test("Predicate evaluated exactly once per visited node (children)")
-    func predicateCalledOncePerVisitedNode() {
+    func predicateCalledExactlyOncePerNode() {
         // Track how many times the predicate is invoked to guard against a
         // regression that double-evaluates (e.g. root check then children
         // check).

--- a/packages/server/appResources/ax-helper/Tests/AXHelperTests/FindLastDescendantTests.swift
+++ b/packages/server/appResources/ax-helper/Tests/AXHelperTests/FindLastDescendantTests.swift
@@ -1,0 +1,330 @@
+import Foundation
+import Testing
+
+// Import the executable's internal namespace. The test target compiles
+// alongside the executable target's sources; `AXHelper` is resolved at link
+// time because the executable sources are non-main-attribute top-level types.
+@testable import ax_helper
+
+// MARK: - Test tree fixture
+
+/// Plain-Swift tree node used to exercise `AXHelper.walkLast` without requiring
+/// a live `AXUIElement`. Each node has a unique `id` so tests can verify
+/// traversal order (not just "a match was found"). Children are declared
+/// in visit order — `walkLast` walks them left-to-right.
+///
+/// Built as a class (not a struct) so nested nodes can reference the same
+/// instance by identity if ever needed; the tests only compare by `id` so
+/// either would work, but a reference type avoids a few `let`-dance gymnastics
+/// when constructing deep trees inline.
+private final class TestNode {
+    let id: Int
+    let children: [TestNode]
+    init(_ id: Int, _ children: [TestNode] = []) {
+        self.id = id
+        self.children = children
+    }
+}
+
+private func kids(_ n: TestNode) -> [TestNode] { n.children }
+
+@Suite("AXHelper.walkLast traversal")
+struct FindLastDescendantTests {
+
+    // MARK: - Predicate & ordering
+
+    @Test("No match returns nil")
+    func noMatchReturnsNil() {
+        let tree = TestNode(1, [TestNode(2), TestNode(3, [TestNode(4)])])
+        let result = AXHelper.walkLast(
+            root: tree,
+            children: kids,
+            matches: { _ in false },
+            maxDepth: 10,
+            skipRoot: false
+        )
+        #expect(result == nil)
+    }
+
+    @Test("Root-only match is returned when no descendants match")
+    func rootMatchReturnedWhenNoDescendantMatches() {
+        let tree = TestNode(42, [TestNode(1), TestNode(2)])
+        let result = AXHelper.walkLast(
+            root: tree,
+            children: kids,
+            matches: { $0.id == 42 },
+            maxDepth: 10,
+            skipRoot: false
+        )
+        #expect(result?.id == 42)
+    }
+
+    @Test("Returns last match in DFS tree order when multiple descendants match")
+    func lastMatchInDFSOrderWins() {
+        // Pre-order DFS visits: 1, 2, 5 (first), 3, 6 (second), 4.
+        // All three of {5, 6, 7} set .isMatch via a distinct marker id >= 100.
+        //   root
+        //   ├─ 2
+        //   │  └─ 100   <- match A (first)
+        //   ├─ 3
+        //   │  └─ 101   <- match B (second, should win)
+        //   └─ 4
+        let tree = TestNode(1, [
+            TestNode(2, [TestNode(100)]),
+            TestNode(3, [TestNode(101)]),
+            TestNode(4)
+        ])
+        let result = AXHelper.walkLast(
+            root: tree,
+            children: kids,
+            matches: { $0.id >= 100 },
+            maxDepth: 10,
+            skipRoot: false
+        )
+        #expect(result?.id == 101)
+    }
+
+    @Test("Deepest last match wins over earlier sibling match")
+    func deeperLaterMatchWinsOverShallower() {
+        // Earlier match at depth 1 (id=100) must be overwritten by a later,
+        // deeper match at depth 3 (id=101) reached via the second child.
+        //   root
+        //   ├─ 100        <- depth 1, match A
+        //   └─ 2
+        //      └─ 3
+        //         └─ 101  <- depth 3, match B (should win)
+        let tree = TestNode(1, [
+            TestNode(100),
+            TestNode(2, [TestNode(3, [TestNode(101)])])
+        ])
+        let result = AXHelper.walkLast(
+            root: tree,
+            children: kids,
+            matches: { $0.id >= 100 },
+            maxDepth: 10,
+            skipRoot: false
+        )
+        #expect(result?.id == 101)
+    }
+
+    @Test("Earlier match is not overwritten by later non-match")
+    func earlierMatchPreservedWhenLaterSiblingsDoNotMatch() {
+        //   root
+        //   ├─ 100        <- match (should win)
+        //   ├─ 2
+        //   └─ 3
+        let tree = TestNode(1, [TestNode(100), TestNode(2), TestNode(3)])
+        let result = AXHelper.walkLast(
+            root: tree,
+            children: kids,
+            matches: { $0.id == 100 },
+            maxDepth: 10,
+            skipRoot: false
+        )
+        #expect(result?.id == 100)
+    }
+
+    // MARK: - Depth bounds
+
+    @Test("Nodes beyond maxDepth are not visited")
+    func respectsMaxDepth() {
+        // Chain: root (depth 0) -> 2 (depth 1) -> 3 (depth 2) -> 100 (depth 3).
+        // With maxDepth=2, only root and 2 are visited. The match at depth 3
+        // must NOT be found; result is nil.
+        let tree = TestNode(1, [TestNode(2, [TestNode(3, [TestNode(100)])])])
+        let result = AXHelper.walkLast(
+            root: tree,
+            children: kids,
+            matches: { $0.id == 100 },
+            maxDepth: 2,
+            skipRoot: false
+        )
+        #expect(result == nil)
+    }
+
+    @Test("maxDepth of 0 yields nil even if root matches")
+    func maxDepthZeroReturnsNilEvenWhenRootMatches() {
+        // `maxDepth` is a strict upper bound on `depth` — with maxDepth=0, the
+        // initial `depth < maxDepth` guard fails immediately and nothing is
+        // visited. Root match is ignored. This matches the pre-existing
+        // AXUIElement semantics (a callable bound of 0 = "do nothing").
+        let tree = TestNode(100)
+        let result = AXHelper.walkLast(
+            root: tree,
+            children: kids,
+            matches: { _ in true },
+            maxDepth: 0,
+            skipRoot: false
+        )
+        #expect(result == nil)
+    }
+
+    @Test("Match exactly at maxDepth boundary is found; one past is not")
+    func maxDepthBoundaryInclusive() {
+        // Chain: 1 -> 2 -> 3 -> 4. maxDepth=3 visits depths 0..2 (nodes 1, 2, 3).
+        // maxDepth=4 visits depths 0..3 (nodes 1, 2, 3, 4).
+        let deep = TestNode(1, [TestNode(2, [TestNode(3, [TestNode(4)])])])
+
+        let atBoundary = AXHelper.walkLast(
+            root: deep,
+            children: kids,
+            matches: { $0.id == 3 },
+            maxDepth: 3,
+            skipRoot: false
+        )
+        #expect(atBoundary?.id == 3)
+
+        let justPast = AXHelper.walkLast(
+            root: deep,
+            children: kids,
+            matches: { $0.id == 4 },
+            maxDepth: 3,
+            skipRoot: false
+        )
+        #expect(justPast == nil)
+
+        let included = AXHelper.walkLast(
+            root: deep,
+            children: kids,
+            matches: { $0.id == 4 },
+            maxDepth: 4,
+            skipRoot: false
+        )
+        #expect(included?.id == 4)
+    }
+
+    // MARK: - skipRoot semantics (#58)
+
+    @Test("skipRoot=false honours a root match")
+    func skipRootFalseHonoursRootMatch() {
+        let tree = TestNode(100, [TestNode(2), TestNode(3)])
+        let result = AXHelper.walkLast(
+            root: tree,
+            children: kids,
+            matches: { $0.id == 100 },
+            maxDepth: 10,
+            skipRoot: false
+        )
+        #expect(result?.id == 100)
+    }
+
+    @Test("skipRoot=true ignores a root match")
+    func skipRootTrueIgnoresRootMatch() {
+        // Root (id=100) would match, but skipRoot suppresses it. No descendant
+        // matches, so the result is nil.
+        let tree = TestNode(100, [TestNode(2), TestNode(3)])
+        let result = AXHelper.walkLast(
+            root: tree,
+            children: kids,
+            matches: { $0.id == 100 },
+            maxDepth: 10,
+            skipRoot: true
+        )
+        #expect(result == nil)
+    }
+
+    @Test("skipRoot=true still walks children and returns descendant match")
+    func skipRootTrueStillWalksChildren() {
+        // Root (id=100) would match but is skipped; descendant (id=100 also)
+        // IS returned because skipRoot only applies to the entry-level root.
+        let tree = TestNode(100, [
+            TestNode(2),
+            TestNode(3, [TestNode(100)])  // the real target
+        ])
+        let result = AXHelper.walkLast(
+            root: tree,
+            children: kids,
+            matches: { $0.id == 100 },
+            maxDepth: 10,
+            skipRoot: true
+        )
+        #expect(result?.id == 100)
+        // To be sure this isn't the root being returned by accident, use
+        // identity on the nested node: rebuild with distinct markers.
+        let sentinel = TestNode(999)
+        let tree2 = TestNode(100, [TestNode(2), TestNode(3, [sentinel])])
+        let result2 = AXHelper.walkLast(
+            root: tree2,
+            children: kids,
+            matches: { $0.id == 999 || $0.id == 100 },
+            maxDepth: 10,
+            skipRoot: true
+        )
+        #expect(result2?.id == 999)
+    }
+
+    @Test("skipRoot does not cascade into descendant recursion")
+    func skipRootDoesNotCascade() {
+        // skipRoot should ONLY skip the original entry root. Every descendant
+        // must have its predicate evaluated normally. Here, the only match is a
+        // direct child of the root — if skipRoot incorrectly cascaded, it would
+        // suppress that child's match and return nil.
+        let tree = TestNode(1, [TestNode(100), TestNode(2)])
+        let result = AXHelper.walkLast(
+            root: tree,
+            children: kids,
+            matches: { $0.id == 100 },
+            maxDepth: 10,
+            skipRoot: true
+        )
+        #expect(result?.id == 100)
+    }
+
+    // MARK: - Edge cases
+
+    @Test("Empty children tree with matching root")
+    func leafRootMatches() {
+        let leaf = TestNode(42)
+        let result = AXHelper.walkLast(
+            root: leaf,
+            children: kids,
+            matches: { $0.id == 42 },
+            maxDepth: 10,
+            skipRoot: false
+        )
+        #expect(result?.id == 42)
+    }
+
+    @Test("Predicate evaluated exactly once per visited node (children)")
+    func predicateCalledOncePerVisitedNode() {
+        // Track how many times the predicate is invoked to guard against a
+        // regression that double-evaluates (e.g. root check then children
+        // check).
+        let tree = TestNode(1, [TestNode(2), TestNode(3, [TestNode(4)])])
+        var calls = 0
+        _ = AXHelper.walkLast(
+            root: tree,
+            children: kids,
+            matches: { _ in calls += 1; return false },
+            maxDepth: 10,
+            skipRoot: false
+        )
+        #expect(calls == 4)  // 1 + 2 + 3 + 4
+    }
+
+    @Test("skipRoot=true skips exactly one predicate evaluation")
+    func skipRootSavesOnePredicateCall() {
+        let tree = TestNode(1, [TestNode(2), TestNode(3, [TestNode(4)])])
+        var callsFull = 0
+        _ = AXHelper.walkLast(
+            root: tree,
+            children: kids,
+            matches: { _ in callsFull += 1; return false },
+            maxDepth: 10,
+            skipRoot: false
+        )
+
+        var callsSkipped = 0
+        _ = AXHelper.walkLast(
+            root: tree,
+            children: kids,
+            matches: { _ in callsSkipped += 1; return false },
+            maxDepth: 10,
+            skipRoot: true
+        )
+
+        #expect(callsFull == 4)
+        #expect(callsSkipped == 3)
+        #expect(callsFull - callsSkipped == 1)
+    }
+}


### PR DESCRIPTION
## Summary

Addresses two follow-ups from PR #54 review:

### #58 (perf) — skipRoot parameter

`AXHelper.findLastDescendant` previously evaluated its predicate on the entry root even when callers knew the root could never match (windows / app elements vs. the Sticker AXGroup predicate). Added opt-in `skipRoot: Bool = false` to both `findLastDescendant` and the `findLastStickerGroup` wrapper. When `true`, predicate is only evaluated on descendants.

Updated `main.swift` (both focused-window and windows[] fallback paths) to pass `skipRoot: true`. Saves one predicate call plus two AX attribute fetches (`AXRole`, `AXIdentifier`) per tapback. Default stays `false` — no behavior change for existing callers.

### #59 (tests) — traversal unit tests

Extracted the traversal loop into a pure generic helper `AXHelper.walkLast<T>(root:children:matches:maxDepth:skipRoot:)`. The `AXUIElement` API delegates to it by passing an `AXChildren` closure. Tests drive `walkLast` directly with a plain-Swift tree fixture — no `AXUIElement` mocking needed, no new dependencies.

Added `FindLastDescendantTests.swift` with 15 tests covering:

- **Traversal order:** last match in DFS order wins; deeper later matches override shallower earlier ones; earlier matches preserved when later siblings don't match.
- **Depth bounds:** `maxDepth` respected; `maxDepth=0` yields nil even when root matches; boundary behavior at exact depth.
- **Predicate semantics:** no match returns nil; leaf root matches; predicate invoked exactly once per visited node.
- **skipRoot (#58):** false honors root, true ignores root but still walks children, scoped to entry root only (doesn't cascade), saves exactly one predicate call.

`Package.swift`: test target now depends on the `ax-helper` executable target so `@testable import ax_helper` resolves for the new in-process tests. `CLITests.swift` integration tests (which fork the built binary) are unchanged and unaffected.

## Verification

- `swift build` — clean, no warnings beyond pre-existing swift-testing package deprecation.
- `swift test` — all 26 tests pass (11 existing + 15 new).
- Public `AXUIElement`-facing API (`findLastDescendant`, `findLastStickerGroup`, `attribute`) unchanged; new parameter is defaulted.

## Design notes

Chose the dependency-injected-children approach (Option C in the plan) over a protocol abstraction: minimal API churn, the production code path is untouched (same recursion, same ordering), tests use trivial Swift values. The pure helper `walkLast` is additive — not a replacement for the AX API surface.

Closes #58
Closes #59