### PR TITLE
docs(architecture): iMessage send flow + webhook delivery diagrams

### DIFF
--- a/docs/architecture/imessage-send-flow.md
+++ b/docs/architecture/imessage-send-flow.md
@@ -1,0 +1,77 @@
+# iMessage send flow
+
+This document maps how `bluebubbles-server` sends an outbound iMessage from a REST/socket request down to `chat.db`, and how that path diverges on macOS 26 (Tahoe). The split is driven by the kernel-level Launch Constraints introduced in Tahoe, which killed DYLIB injection into `Messages.app` / `imagent` — see [`research/2026-04-14-private-api-tahoe.md`](../research/2026-04-14-private-api-tahoe.md). On older macOS the Private API path (DYLIB hook) is the preferred high-fidelity sender; on Tahoe that path is gone, so all sends fall back to AppleScript driving `Messages.app`, with `ax-helper` covering adjacent UI actions (tapback, mark-read, navigate) that the Private API used to handle.
+
+Important: as of this writing **`ax-helper` does NOT implement send.** Inspect `packages/server/appResources/ax-helper/Sources/main.swift` — the only commands are `tapback`, `mark-read`, `navigate`, `check`. Send on Tahoe still goes through `ActionHandler.sendMessage` → AppleScript (`packages/server/src/server/api/apple/scripts.ts::sendMessage`) with the `mapServiceType` GUID fix patching `any;-;` back to `iMessage` for the `service type` parameter. A pure-AX send path (focus compose field, set value, simulate Return) is described as plausible in `research/2026-04-14-ax-typing-indicators.md` but is **research/proposed**, not shipped.
+
+Out of scope: inbound message receive (chat.db poller in `databases/imessage/`), webhook outbound delivery (`services/webhookService` — see [`webhook-delivery.md`](./webhook-delivery.md)), and Private API attachment sends (`PrivateApiAttachment`).
+
+## Send-path decision tree
+
+```mermaid
+flowchart TD
+    A[HTTP/Socket: send-message] --> B[MessageInterface.sendMessageSync]
+    B --> C{method param}
+    C -->|private-api| D[sendMessagePrivateApi]
+    C -->|apple-script| E[ActionHandler.sendMessage]
+    D --> F{macOS version}
+    F -->|<= macOS 15| G[PrivateApiMessage.sendApiMessage<br/>action=send-message]
+    F -->|macOS 26 Tahoe| X[DYLIB inject blocked<br/>Launch Constraints + AMFI]
+    X --> E
+    G --> H[helper DYLIB in Messages.app<br/>-> imagent XPC]
+    H --> Z[(chat.db)]
+    E --> I[scripts.sendMessage<br/>+ mapServiceType any to iMessage]
+    I --> J[FileSystem.executeAppleScript<br/>osascript -> Messages.app]
+    J -->|timeout / -1700| K[restartMessages then retry]
+    K --> L[scripts.sendMessageFallback]
+    J --> Z
+    L --> Z
+    Z --> M[MessagePromise resolves<br/>via outgoingMessageManager]
+    M --> N[return Message entity]
+
+    subgraph LegacyPrivateAPI[Legacy: Private API DYLIB]
+        D
+        G
+        H
+    end
+    subgraph TahoeAppleScript[Tahoe + fallback: AppleScript]
+        E
+        I
+        J
+        K
+        L
+    end
+```
+
+## Path comparison
+
+| Path                                   | OS                           | Mechanism                                                                                                                                                               | Reliability                                                      | Primary failure mode                                                     |
+| -------------------------------------- | ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| Legacy Private API                     | <= macOS 15 (Sonoma/Sequoia) | DYLIB injected into `Messages.app`, XPC to `imagent`, called via `PrivateApiMessage.sendApiMessage("send-message", ...)`                                                | High — supports effects, subjects, attributedBody, edit/unsend   | DYLIB load fails, helper socket disconnect                               |
+| AppleScript (default + Tahoe fallback) | All; required on macOS 26    | `ActionHandler.sendMessage` → `scripts.ts::sendMessage` with `mapServiceType` → `osascript` driving `Messages.app`; one-retry-after-restart, then `sendMessageFallback` | Medium — text + simple attachments only; no effects, no subjects | AppleScript timeout, error -1700 (bad service type), Messages.app wedged |
+| ax-helper (NOT for send today)         | macOS 13+; targeted at Tahoe | Swift CLI in `appResources/ax-helper/`, invoked by `services/AxService.ts` via `execFile` with a 5s timeout and `Sema(1)` queue                                         | N/A for send                                                     | Permission denied, `messages_not_running`, AX action missing             |
+
+## Failure modes
+
+- **TCC / Accessibility not granted** — `MessagesApp.checkAccessibility()` in `ax-helper/Sources/main.swift` exits with `permission_denied`; `AxService.exec` rejects with that string and the HTTP layer surfaces it. Send itself is unaffected today (AppleScript path), but tapback/mark-read/navigate fail. Re-grant flow lives in the openclaw-infra repo (`docs/runbooks/bb-tcc-regrant.md`) — same root cause as openclaw-infra #1053 but for a closed app, so re-granting after every BB.app upgrade is the only remediation.
+- **Messages.app not running** — ax-helper exits `messages_not_running`; AppleScript path implicitly launches Messages via `tell application "Messages"`, but on Tahoe a fully-quit Messages.app can stall the first send (caught by the timeout/`1002` retry branch in `ActionHandler.sendMessage`).
+- **Conversation not findable / GUID mismatch** — On Tahoe, chat GUIDs are stored as `any;-;<addr>` but AppleScript's `service type` only accepts `iMessage|SMS|RCS`. Without `mapServiceType` (`apple/scripts.ts:16`) the script throws error -1700. Symptom: `ActionHandler.sendMessage` falls through to `sendMessageFallback`, which only works for DMs, then re-throws.
+- **ax-helper crash / non-zero exit** — `AxService.exec` parses stdout JSON regardless of exit code; if `result.ok === false` it rejects with `result.error`, otherwise classifies `ETIMEDOUT`/`SIGTERM` as `"timeout"`. Send today is not gated on this — only AX-driven endpoints (`/api/v1/ax/*`) are.
+- **Confirmation source** — Send is **not** synchronous over a real ack from `imagent`. `MessageInterface.sendMessageSync` registers a `MessagePromise` against `Server().messageManager` keyed on `(chatGuid, text, sentAt)`, then awaits resolution from the chat.db poller in `databases/imessage/`. Both Private API and AppleScript paths land in chat.db; both rely on the poll to resolve the awaiter.
+
+## Related
+
+- [`docs/research/2026-04-14-private-api-tahoe.md`](../research/2026-04-14-private-api-tahoe.md) — why DYLIB injection / `imagent` XPC are dead on Tahoe
+- [`docs/research/2026-04-14-ax-typing-indicators.md`](../research/2026-04-14-ax-typing-indicators.md) — AX prototype results; SetValue-vs-keystroke open question for typing/send-via-AX
+- [`docs/research/2026-04-14-headless-operation.md`](../research/2026-04-14-headless-operation.md) — FDA propagation and headless-mode blockers
+- [`webhook-delivery.md`](./webhook-delivery.md) — outbound notification flow once a message lands in chat.db
+- [README — Fork Changes / Tahoe Fixes](../../README.md#macos-26-tahoe-fixes) — shipped fixes (#18 GUID, #19 attributedBody, #43 ax-helper)
+- `packages/server/src/server/api/interfaces/messageInterface.ts` — `sendMessageSync` entry point
+- `packages/server/src/server/api/apple/actions.ts` — AppleScript send + retry/fallback
+- `packages/server/src/server/api/apple/scripts.ts` — `mapServiceType`, `sendMessage`, `sendMessageFallback`
+- `packages/server/src/server/api/privateApi/apis/PrivateApiMessage.ts` — Private API send (legacy macOS only)
+- `packages/server/appResources/ax-helper/Sources/main.swift` — ax-helper command set (no `send` today)
+- `packages/server/src/server/services/AxService.ts` — Node-side ax-helper invoker
+- openclaw-infra `docs/imessage-setup.md` — one-way integration from openclaw-infra side (BlueBubbles channel, private-network allow, TCC re-grant after BB.app upgrade)
+
+_Last updated: 2026-05-03_

--- a/docs/architecture/imessage-send-flow.md
+++ b/docs/architecture/imessage-send-flow.md
@@ -26,7 +26,7 @@ flowchart TD
     K --> L[scripts.sendMessageFallback]
     J --> Z
     L --> Z
-    Z --> M[MessagePromise resolves<br/>via outgoingMessageManager]
+    Z --> M[MessagePromise resolves<br/>via Server.messageManager]
     M --> N[return Message entity]
 
     subgraph LegacyPrivateAPI[Legacy: Private API DYLIB]
@@ -55,9 +55,9 @@ flowchart TD
 
 - **TCC / Accessibility not granted** — `MessagesApp.checkAccessibility()` in `ax-helper/Sources/main.swift` exits with `permission_denied`; `AxService.exec` rejects with that string and the HTTP layer surfaces it. Send itself is unaffected today (AppleScript path), but tapback/mark-read/navigate fail. Re-grant flow lives in the openclaw-infra repo (`docs/runbooks/bb-tcc-regrant.md`) — same root cause as openclaw-infra #1053 but for a closed app, so re-granting after every BB.app upgrade is the only remediation.
 - **Messages.app not running** — ax-helper exits `messages_not_running`; AppleScript path implicitly launches Messages via `tell application "Messages"`, but on Tahoe a fully-quit Messages.app can stall the first send (caught by the timeout/`1002` retry branch in `ActionHandler.sendMessage`).
-- **Conversation not findable / GUID mismatch** — On Tahoe, chat GUIDs are stored as `any;-;<addr>` but AppleScript's `service type` only accepts `iMessage|SMS|RCS`. Without `mapServiceType` (`apple/scripts.ts:16`) the script throws error -1700. Symptom: `ActionHandler.sendMessage` falls through to `sendMessageFallback`, which only works for DMs, then re-throws.
+- **Conversation not findable / GUID mismatch** — On Tahoe, chat GUIDs are stored as `any;-;<addr>` but AppleScript's `service type` only accepts `iMessage|SMS|RCS`. Without the `mapServiceType` export from `apple/scripts.ts` the script throws error -1700. Symptom: `ActionHandler.sendMessage` falls through to `sendMessageFallback`, which only works for DMs, then re-throws.
 - **ax-helper crash / non-zero exit** — `AxService.exec` parses stdout JSON regardless of exit code; if `result.ok === false` it rejects with `result.error`, otherwise classifies `ETIMEDOUT`/`SIGTERM` as `"timeout"`. Send today is not gated on this — only AX-driven endpoints (`/api/v1/ax/*`) are.
-- **Confirmation source** — Send is **not** synchronous over a real ack from `imagent`. `MessageInterface.sendMessageSync` registers a `MessagePromise` against `Server().messageManager` keyed on `(chatGuid, text, sentAt)`, then awaits resolution from the chat.db poller in `databases/imessage/`. Both Private API and AppleScript paths land in chat.db; both rely on the poll to resolve the awaiter.
+- **Confirmation source** — Send is **not** synchronous over a real ack from `imagent`. `MessageInterface.sendMessageSync` registers a `MessagePromise` against `Server().messageManager` keyed on `(chatGuid, text, sentAt)` — and on `subject` when a non-empty subject is supplied (`MessagePromise.isSame()` in `messagePromise.ts` adds subject to the match predicate when both sides are non-empty). It then awaits resolution from the chat.db poller in `databases/imessage/`. Both Private API and AppleScript paths land in chat.db; both rely on the poll to resolve the awaiter.
 
 ## Related
 

--- a/docs/architecture/webhook-delivery.md
+++ b/docs/architecture/webhook-delivery.md
@@ -2,7 +2,7 @@
 
 This document describes how `bluebubbles-server` notifies HTTP subscribers (such as the openclaw gateway) when an iMessage event happens — a new message arrives, a message is updated, a chat is renamed, etc. Audience: someone debugging "the openclaw gateway didn't receive a message".
 
-The dispatch path is short. The iMessage database listeners (`packages/server/src/server/api/imessage/listeners/`) poll `chat.db` and emit typed events. `Server()` forwards each event to `WebhookService.dispatch()` (`packages/server/src/server/index.ts:1199`), which loads every row from the `webhook` table, filters by event type, and POSTs the payload to each subscriber URL.
+The dispatch path is short. The iMessage database listeners (`packages/server/src/server/api/imessage/listeners/`) poll `chat.db` and emit typed events. `Server()` forwards each event to `WebhookService.dispatch()` (called from `packages/server/src/server/index.ts` near the bottom of the listener wire-up), which loads every row from the `webhook` table, filters by event type, and POSTs the payload to each subscriber URL.
 
 **Retry IS shipped.** Issue #15 / PR #24 (`fix: add exponential backoff retry for webhook delivery`, merged 2026-04-14) replaced the original fire-and-forget call with an in-process retry loop: 3 attempts with exponential backoff (1s, 2s, then a final attempt). Auth header support (Issue #11) is also shipped — every outbound POST carries `Authorization: Bearer <server-password>` when a password is configured. There is still no persistent dead-letter queue: if all 3 attempts fail, the failure is logged and the event is dropped.
 
@@ -15,7 +15,7 @@ sequenceDiagram
     participant S as Server()
     participant W as WebhookService
     participant R as webhook table (TypeORM)
-    participant U as Subscriber URL<br/>(e.g. openclaw gateway)
+    participant U as Subscriber URL (e.g. openclaw gateway)
 
     DB->>L: row inserted / updated
     L->>S: emit("new-message", data)
@@ -40,18 +40,18 @@ sequenceDiagram
 stateDiagram-v2
     [*] --> Attempt1
     Attempt1 --> Success: 2xx response
-    Attempt1 --> Wait1s: error / non-2xx
-    Wait1s --> Attempt2: after 1000ms
+    Attempt1 --> Backoff1: error / non-2xx
+    Backoff1 --> Attempt2: after baseDelay
     Attempt2 --> Success: 2xx response
-    Attempt2 --> Wait2s: error / non-2xx
-    Wait2s --> Attempt3: after 2000ms
+    Attempt2 --> Backoff2: error / non-2xx
+    Backoff2 --> Attempt3: after baseDelay × 2
     Attempt3 --> Success: 2xx response
     Attempt3 --> Dropped: error / non-2xx
     Success --> [*]
     Dropped --> [*]: log.warn, no DLQ
 ```
 
-Delay formula: `baseDelayMs * 2^(attempt-1)` with `baseDelayMs = 1000` (overridable as `retryBaseDelayMs` in tests). After attempt 3 the rejection bubbles out of `sendPost`; the caller in `dispatch()` catches it and writes a `Failed to dispatch "<type>" event to webhook after retries` warning.
+Delay formula: `baseDelayMs * 2^(attempt-1)` with `baseDelayMs = 1000` (i.e. 1s before attempt 2, 2s before attempt 3). The class property `retryBaseDelayMs` on `WebhookService` is the override injection point used by tests; `sendPost` aliases it locally as `baseDelayMs`. After attempt 3 the rejection bubbles out of `sendPost`; the caller in `dispatch()` catches it and writes a `Failed to dispatch "<type>" event to webhook after retries: <url>` warning.
 
 ## Current vs original behavior
 
@@ -66,7 +66,7 @@ Delay formula: `baseDelayMs * 2^(attempt-1)` with `baseDelayMs = 1000` (overrida
 
 ## Debugging tips
 
-- On the BB-server side, grep the server log for `WebhookService` — `Dispatching event to webhook: <url>` confirms the dispatch fired, `Webhook delivery failed (attempt N/3)` shows mid-retry failures, and `Failed to dispatch "<type>" event to webhook after retries` is the terminal failure line.
+- On the BB-server side, grep the server log for `WebhookService`. The terminal failure line is the always-visible signal: `Failed to dispatch "<type>" event to webhook after retries: <url>` is emitted at `warn` level and will appear in production logs by default. The earlier markers — `Dispatching event to webhook: <url>` (every dispatch attempt) and `Webhook delivery failed (attempt N/3)` (each retry) — are emitted at `debug` level and require enabling debug logging in the BB server settings to be visible. If you grep for `Dispatching` and find nothing, that does NOT prove dispatch never ran; check the `warn`-level line first.
 - Subscriber list is the `webhook` table in the server's TypeORM SQLite database (entity: `packages/server/src/server/databases/server/entity/Webhook.ts`). Inspect via the BB-server UI's Webhooks page or query the DB directly. Each row stores `url` and a JSON-encoded `events` array; `["*"]` means "all events".
 - The auth header is the server password (`Server().repo.getConfig("password")`), NOT a dedicated webhook secret. If gateway-side auth fails, confirm the BB-server password matches what the gateway expects.
 - On the gateway side, correlate by timestamp with the inbound webhook handler log on the openclaw gateway (BlueBubbles channel) — a BB-side `Failed to dispatch ... after retries` with no matching gateway-side receive entry confirms the message never landed; a successful BB-side dispatch but no gateway entry points to a gateway routing/auth issue rather than a delivery issue.

--- a/docs/architecture/webhook-delivery.md
+++ b/docs/architecture/webhook-delivery.md
@@ -1,0 +1,84 @@
+# Webhook delivery
+
+This document describes how `bluebubbles-server` notifies HTTP subscribers (such as the openclaw gateway) when an iMessage event happens — a new message arrives, a message is updated, a chat is renamed, etc. Audience: someone debugging "the openclaw gateway didn't receive a message".
+
+The dispatch path is short. The iMessage database listeners (`packages/server/src/server/api/imessage/listeners/`) poll `chat.db` and emit typed events. `Server()` forwards each event to `WebhookService.dispatch()` (`packages/server/src/server/index.ts:1199`), which loads every row from the `webhook` table, filters by event type, and POSTs the payload to each subscriber URL.
+
+**Retry IS shipped.** Issue #15 / PR #24 (`fix: add exponential backoff retry for webhook delivery`, merged 2026-04-14) replaced the original fire-and-forget call with an in-process retry loop: 3 attempts with exponential backoff (1s, 2s, then a final attempt). Auth header support (Issue #11) is also shipped — every outbound POST carries `Authorization: Bearer <server-password>` when a password is configured. There is still no persistent dead-letter queue: if all 3 attempts fail, the failure is logged and the event is dropped.
+
+## Event → subscriber dispatch
+
+```mermaid
+sequenceDiagram
+    participant DB as chat.db (poller)
+    participant L as MessageListener
+    participant S as Server()
+    participant W as WebhookService
+    participant R as webhook table (TypeORM)
+    participant U as Subscriber URL<br/>(e.g. openclaw gateway)
+
+    DB->>L: row inserted / updated
+    L->>S: emit("new-message", data)
+    S->>W: dispatch({ type, data })
+    W->>R: getWebhooks()
+    R-->>W: [{ url, events }, ...]
+    loop for each webhook
+        W->>W: filter by event type<br/>("*" or includes type)
+        W->>U: POST url<br/>Authorization: Bearer <password><br/>Content-Type: application/json
+        alt 2xx
+            U-->>W: ack -> done
+        else network error / non-2xx
+            U-->>W: error
+            W->>W: retry with backoff (see state diagram)
+        end
+    end
+```
+
+## Retry state machine (shipped, Issue #15 / PR #24)
+
+```mermaid
+stateDiagram-v2
+    [*] --> Attempt1
+    Attempt1 --> Success: 2xx response
+    Attempt1 --> Wait1s: error / non-2xx
+    Wait1s --> Attempt2: after 1000ms
+    Attempt2 --> Success: 2xx response
+    Attempt2 --> Wait2s: error / non-2xx
+    Wait2s --> Attempt3: after 2000ms
+    Attempt3 --> Success: 2xx response
+    Attempt3 --> Dropped: error / non-2xx
+    Success --> [*]
+    Dropped --> [*]: log.warn, no DLQ
+```
+
+Delay formula: `baseDelayMs * 2^(attempt-1)` with `baseDelayMs = 1000` (overridable as `retryBaseDelayMs` in tests). After attempt 3 the rejection bubbles out of `sendPost`; the caller in `dispatch()` catches it and writes a `Failed to dispatch "<type>" event to webhook after retries` warning.
+
+## Current vs original behavior
+
+| Aspect                        | Original (pre-#15)           | Current (shipped, PR #24)                                      |
+| ----------------------------- | ---------------------------- | -------------------------------------------------------------- |
+| Retries                       | None — fire-and-forget       | 3 attempts total                                               |
+| Backoff                       | N/A                          | Exponential: 1s, 2s before final                               |
+| Dead-letter                   | N/A                          | None — failure is logged and dropped                           |
+| Logging                       | Single warn on first failure | `debug` per retry, `warn` after final failure with status text |
+| Auth header                   | None (pre-#11)               | `Authorization: Bearer <password>` when configured (#11)       |
+| Subscriber removal on failure | Never                        | Never — webhook row stays in DB                                |
+
+## Debugging tips
+
+- On the BB-server side, grep the server log for `WebhookService` — `Dispatching event to webhook: <url>` confirms the dispatch fired, `Webhook delivery failed (attempt N/3)` shows mid-retry failures, and `Failed to dispatch "<type>" event to webhook after retries` is the terminal failure line.
+- Subscriber list is the `webhook` table in the server's TypeORM SQLite database (entity: `packages/server/src/server/databases/server/entity/Webhook.ts`). Inspect via the BB-server UI's Webhooks page or query the DB directly. Each row stores `url` and a JSON-encoded `events` array; `["*"]` means "all events".
+- The auth header is the server password (`Server().repo.getConfig("password")`), NOT a dedicated webhook secret. If gateway-side auth fails, confirm the BB-server password matches what the gateway expects.
+- On the gateway side, correlate by timestamp with the inbound webhook handler log on the openclaw gateway (BlueBubbles channel) — a BB-side `Failed to dispatch ... after retries` with no matching gateway-side receive entry confirms the message never landed; a successful BB-side dispatch but no gateway entry points to a gateway routing/auth issue rather than a delivery issue.
+
+## Related
+
+- [`imessage-send-flow.md`](./imessage-send-flow.md) — how a message lands in chat.db in the first place (which then triggers the listener emit above)
+- README — Fork Changes → Webhook retry (#15) and Auth header (#11): [../../README.md](../../README.md)
+- Plan — Issue #15 task and rollout: [`../superpowers/plans/2026-04-13-ci-pipeline-and-fixes.md`](../superpowers/plans/2026-04-13-ci-pipeline-and-fixes.md)
+- Spec — design context for the CI + fixes batch: [`../superpowers/specs/2026-04-13-ci-pipeline-and-fixes-design.md`](../superpowers/specs/2026-04-13-ci-pipeline-and-fixes-design.md)
+- Implementation: `packages/server/src/server/services/webhookService/index.ts`
+- Subscriber entity: `packages/server/src/server/databases/server/entity/Webhook.ts`
+- Gateway-side receiving end (openclaw-infra): `docs/imessage-setup.md` in the openclaw-infra repo
+
+_Last updated: 2026-05-03_


### PR DESCRIPTION
## Summary

Adds 2 mermaid diagrams from the cross-repo doc-review pass on 2026-05-03 (companion to openclaw-infra docs/architecture/):

1. **iMessage send flow** (`docs/architecture/imessage-send-flow.md`) — flowchart of the legacy Private API DYLIB path vs the Tahoe AppleScript path, with the mapServiceType GUID fix on the AppleScript branch. Explicit note that ax-helper does NOT implement send today (only tapback, mark-read, navigate, check). Path comparison table, failure-mode list, async confirmation note (MessagePromise + chat.db poll).

2. **Webhook delivery** (`docs/architecture/webhook-delivery.md`) — sequenceDiagram for chat.db -> MessageListener -> Server() -> WebhookService -> subscriber, plus a stateDiagram-v2 for the shipped 3-attempt 1s/2s exponential backoff (Issue #15 / PR #24, merged 2026-04-14). Documents: no DLQ, debug-vs-warn log levels, Authorization: Bearer auth header (Issue #11). Cross-links to the openclaw-infra gateway-side receiving end.

## Review trail

- Self-review: clean (no findings)
- Correctness-reviewer: 8 findings (2 High + 3 Medium + 2 Low + 1 observation) — all High/Medium + top 2 Low fixed in commit `a3a193b0`
- Fix-reviewer: confirmed all 7 fixes; flagged a pre-existing `<br/>` in a sequenceDiagram participant label as a separate mermaid regression — also fixed in `a3a193b0`

## Files

- `docs/architecture/imessage-send-flow.md` (new, 78 lines after fixes)
- `docs/architecture/webhook-delivery.md` (new, 84 lines after fixes)

No code changes.