### PR TITLE
chore(deps): bump xmldom and protobufjs to fix Trivy CRITICAL+HIGH CVEs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bluebubbles-server",
-  "version": "1.12.0",
+  "version": "1.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bluebubbles-server",
-      "version": "1.12.0",
+      "version": "1.15.0",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/*"
@@ -4951,9 +4951,10 @@
       "optional": true
     },
     "node_modules/@protobufjs/codegen": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause",
       "optional": true
     },
     "node_modules/@protobufjs/eventemitter": {
@@ -4979,9 +4980,10 @@
       "optional": true
     },
     "node_modules/@protobufjs/inquire": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.1.tgz",
+      "integrity": "sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==",
+      "license": "BSD-3-Clause",
       "optional": true
     },
     "node_modules/@protobufjs/path": {
@@ -4997,9 +4999,10 @@
       "optional": true
     },
     "node_modules/@protobufjs/utf8": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+      "license": "BSD-3-Clause",
       "optional": true
     },
     "node_modules/@reduxjs/toolkit": {
@@ -6975,9 +6978,9 @@
       }
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.8.12",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.12.tgz",
-      "integrity": "sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==",
+      "version": "0.8.13",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
+      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -16814,22 +16817,23 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.3.2.tgz",
-      "integrity": "sha512-RXyHaACeqXeqAKGLDl68rQKbmObRsTIn4TYVUUug1KfS47YWCo5MacGITEryugIgZqORCvJWEk4l449POg5Txg==",
+      "version": "7.5.6",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.6.tgz",
+      "integrity": "sha512-M71sTMB146U3u0di3yup8iM+zv8yPRNQVr1KK4tyBitl3qFvEGucq/rGDRShD2rsJhtN02RJaJ7j5X5hmy8SJg==",
       "hasInstallScript": true,
+      "license": "BSD-3-Clause",
       "optional": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/codegen": "^2.0.5",
         "@protobufjs/eventemitter": "^1.1.0",
         "@protobufjs/fetch": "^1.1.0",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/inquire": "^1.1.1",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
         "@types/node": ">=13.7.0",
         "long": "^5.0.0"
       },
@@ -20641,7 +20645,7 @@
     },
     "packages/server": {
       "name": "@bluebubbles/server",
-      "version": "1.12.0",
+      "version": "1.15.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -20652,6 +20656,7 @@
         "axios": "^1.7.2",
         "better-sqlite3": "^8.0.1",
         "blurhash": "^1.1.3",
+        "bplist-parser": "^0.3.2",
         "byte-base64": "^1.1.0",
         "compare-versions": "^3.6.0",
         "conditional-decorator": "^0.1.7",

--- a/package.json
+++ b/package.json
@@ -32,5 +32,9 @@
     "concurrently": "^7.0.0",
     "husky": "^9.1.7",
     "lint-staged": "^16.4.0"
+  },
+  "overrides": {
+    "@xmldom/xmldom": "^0.8.13",
+    "protobufjs": "^7.5.5"
   }
 }


### PR DESCRIPTION
## Summary

Fixes Security Scan failures on every PR (most recently #63 — the docs PR) after the May 2026 CVE disclosures:

| Package | Before | After | CVE | Severity |
|---|---|---|---|---|
| @xmldom/xmldom | 0.8.12 | 0.8.13 | CVE-2026-41672, 41673, 41674, 41675 | HIGH ×4 |
| protobufjs | 7.3.2 | 7.5.6 | CVE-2026-41242 (RCE) | CRITICAL |

Both are transitive deps:
- xmldom via plist (macOS plist parsing)
- protobufjs via @grpc/proto-loader, @google-cloud/firestore, google-gax (Firebase/FCM)

## Implementation

- Added `overrides` to root package.json pinning floor versions (`^0.8.13` / `^7.5.5`) — prevents regression on future fresh installs.
- Used `npm update --package-lock-only --ignore-scripts` for targeted lock refresh — only the affected packages and their @protobufjs/* transitives were touched, plus minor stale metadata cleanups in the `packages/server` lock entry that npm picked up along the way (server version 1.12.0 → 1.15.0 alignment, bplist-parser entry already in package.json but missing from lock).

## Diff scope

47 lines in `package-lock.json`, 4 lines in `package.json`. No node_modules wiped, no full re-resolve. Verified post-update lock contents are exactly the patched versions.

## Out of scope

`npm audit` reports 31 other findings (uuid, googleapis-common, ngrok, typeorm transitive). They don't appear in Trivy's HIGH/CRITICAL filter, so they don't fail CI today. Tracking those separately would be a bigger dep-bump effort.

This unblocks PR #63 once merged.