### PR TITLE
docs(readme): add reciprocal openclaw-infra integration callout

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Fork of [BlueBubblesApp/bluebubbles-server](https://github.com/BlueBubblesApp/bluebubbles-server) with macOS 26 Tahoe compatibility fixes and OpenClaw integration.
 
+> **Integration point:** This server is the iMessage bridge consumed by [`markthebest12/openclaw-infra`](https://github.com/markthebest12/openclaw-infra) — that repo's `scripts/bb-pipeline.sh` builds and deploys this fork onto canon, and its [`docs/imessage-setup.md`](https://github.com/markthebest12/openclaw-infra/blob/main/docs/imessage-setup.md) documents the BlueBubbles channel config (allowFrom, dmPolicy, `dangerouslyAllowPrivateNetwork`). For internal architecture see [`docs/architecture/`](docs/architecture/) — `imessage-send-flow.md` (Tahoe AppleScript path vs. legacy Private API) and `webhook-delivery.md` (event dispatch + retry state machine).
+
 ## Fork Changes
 
 ### macOS 26 Tahoe Fixes


### PR DESCRIPTION
## Summary

Phase 2 of the cross-repo doc-review pass. The openclaw-infra README already references this fork; this is the matching reverse direction so a reader landing here knows immediately:

- Which downstream consumes this fork (`markthebest12/openclaw-infra`)
- Where the build/install orchestration lives (`bb-pipeline.sh` in openclaw-infra)
- Where the BB channel config is documented (`docs/imessage-setup.md` in openclaw-infra)
- Where the BB-side internal architecture lives (this repo's `docs/architecture/imessage-send-flow.md` + `webhook-delivery.md`, shipped in PR #63)

One-paragraph blockquote at the top of `README.md`. No other changes.

## Review

Skipped formal /review-changes for this 2-line diff — manually verified all 4 referenced files exist (scripts/bb-pipeline.sh in openclaw-infra, docs/imessage-setup.md in openclaw-infra, docs/architecture/imessage-send-flow.md here, docs/architecture/webhook-delivery.md here).