### PR TITLE
feat(webhook): bump retry budget to 8 attempts (~255s, #71)

### DIFF
--- a/packages/server/src/server/services/webhookService/__tests__/webhookService.test.ts
+++ b/packages/server/src/server/services/webhookService/__tests__/webhookService.test.ts
@@ -44,6 +44,11 @@ describe("WebhookService", () => {
         service = new WebhookService();
         // Use 0ms delay in tests so retries resolve instantly
         service.retryBaseDelayMs = 0;
+        // Tighten retry budget to 3 in tests so existing assertions still
+        // pin a small, deterministic number — the production budget is 8
+        // (see bluebubbles-server#71). Tests for the larger budget set
+        // service.maxRetries explicitly.
+        service.maxRetries = 3;
         // Restore default mock behavior after clearAllMocks
         mockGetWebhooks.mockResolvedValue([]);
         mockGetConfig.mockReturnValue("test-password");
@@ -89,6 +94,29 @@ describe("WebhookService", () => {
             ).rejects.toThrow("ECONNREFUSED");
 
             expect(mockedAxios.post).toHaveBeenCalledTimes(3);
+        });
+
+        it("uses default maxRetries=8 when not overridden (bluebubbles-server#71)", () => {
+            // Construct fresh — no override of maxRetries — and assert the
+            // production budget. The beforeEach above sets maxRetries=3 only
+            // to tighten existing tests; this asserts the shipped default.
+            const fresh = new WebhookService();
+            expect(fresh.maxRetries).toBe(8);
+        });
+
+        it("succeeds on the 8th attempt under the production retry budget", async () => {
+            service.maxRetries = 8;
+            // Reject 7 times, succeed on the 8th — verifies 1+2+4+8+16+32+64+128≈255s
+            // of clock-time budget covers the gateway restart window.
+            for (let i = 0; i < 7; i++) {
+                mockedAxios.post.mockRejectedValueOnce(new Error("ECONNREFUSED"));
+            }
+            mockedAxios.post.mockResolvedValueOnce({ status: 200 });
+
+            await (service as any).sendPost("https://example.com/hook", { type: "test", data: {} });
+
+            expect(mockedAxios.post).toHaveBeenCalledTimes(8);
+            expect(service.log.debug).toHaveBeenCalledWith(expect.stringContaining("attempt 7/8"));
         });
 
         it("includes Authorization header when password is configured", async () => {

--- a/packages/server/src/server/services/webhookService/__tests__/webhookService.test.ts
+++ b/packages/server/src/server/services/webhookService/__tests__/webhookService.test.ts
@@ -42,8 +42,10 @@ describe("WebhookService", () => {
     beforeEach(() => {
         vi.clearAllMocks();
         service = new WebhookService();
-        // Use 0ms delay in tests so retries resolve instantly
+        // Use 0ms delay in tests so retries resolve instantly.
         service.retryBaseDelayMs = 0;
+        // Disable jitter for deterministic assertions on log lines.
+        service.retryJitterFactor = 0;
         // Tighten retry budget to 3 in tests so existing assertions still
         // pin a small, deterministic number — the production budget is 8
         // (see bluebubbles-server#71). Tests for the larger budget set
@@ -53,6 +55,13 @@ describe("WebhookService", () => {
         mockGetWebhooks.mockResolvedValue([]);
         mockGetConfig.mockReturnValue("test-password");
     });
+
+    /** Build an axios-style error with an HTTP status attached. */
+    const httpError = (status: number, message = `Request failed with ${status}`): Error => {
+        const err: Error & { response?: { status: number } } = new Error(message);
+        err.response = { status };
+        return err;
+    };
 
     describe("sendPost retry behavior", () => {
         it("succeeds on first attempt without retry", async () => {
@@ -106,8 +115,12 @@ describe("WebhookService", () => {
 
         it("succeeds on the 8th attempt under the production retry budget", async () => {
             service.maxRetries = 8;
-            // Reject 7 times, succeed on the 8th — verifies 1+2+4+8+16+32+64+128≈255s
-            // of clock-time budget covers the gateway restart window.
+            // Reject 7 times, succeed on the 8th — proves the production
+            // budget can actually deliver after 7 failures. Total clock
+            // time would be 1+2+4+8+16+32+64+128 ≈ 255s in production;
+            // here retryBaseDelayMs is 0 so the test runs instantly. The
+            // budget arithmetic itself is documented on `maxRetries` in
+            // the implementation, not asserted here.
             for (let i = 0; i < 7; i++) {
                 mockedAxios.post.mockRejectedValueOnce(new Error("ECONNREFUSED"));
             }
@@ -117,6 +130,62 @@ describe("WebhookService", () => {
 
             expect(mockedAxios.post).toHaveBeenCalledTimes(8);
             expect(service.log.debug).toHaveBeenCalledWith(expect.stringContaining("attempt 7/8"));
+        });
+
+        it("does NOT retry on 4xx (permanent client error)", async () => {
+            // 401/404/400 mean the webhook target is misconfigured. Retrying
+            // for 255s blocks the slot with no chance of success. PR review
+            // finding (#72) — bluebubbles-server#71.
+            mockedAxios.post.mockRejectedValueOnce(httpError(401, "Unauthorized"));
+
+            await expect(
+                (service as any).sendPost("https://example.com/hook", { type: "test", data: {} })
+            ).rejects.toThrow("Unauthorized");
+
+            expect(mockedAxios.post).toHaveBeenCalledTimes(1);
+        });
+
+        it("DOES retry on 429 (rate-limited)", async () => {
+            // 429 is the one 4xx that's transient — the server is asking us
+            // to back off, not refusing the request shape.
+            mockedAxios.post
+                .mockRejectedValueOnce(httpError(429, "Too Many Requests"))
+                .mockResolvedValueOnce({ status: 200 });
+
+            await (service as any).sendPost("https://example.com/hook", { type: "test", data: {} });
+
+            expect(mockedAxios.post).toHaveBeenCalledTimes(2);
+        });
+
+        it("DOES retry on 5xx (transient server error)", async () => {
+            mockedAxios.post
+                .mockRejectedValueOnce(httpError(503, "Service Unavailable"))
+                .mockResolvedValueOnce({ status: 200 });
+
+            await (service as any).sendPost("https://example.com/hook", { type: "test", data: {} });
+
+            expect(mockedAxios.post).toHaveBeenCalledTimes(2);
+        });
+
+        it("rejects invalid maxRetries values", () => {
+            // maxRetries setter validates input — protects against
+            // Math.pow(2, attempt-1) overflow at large values and against
+            // accidental zero/negative misconfiguration.
+            expect(() => {
+                service.maxRetries = 0;
+            }).toThrow(RangeError);
+            expect(() => {
+                service.maxRetries = -1;
+            }).toThrow(RangeError);
+            expect(() => {
+                service.maxRetries = 21;
+            }).toThrow(RangeError);
+            expect(() => {
+                service.maxRetries = 1.5;
+            }).toThrow(RangeError);
+            expect(() => {
+                service.maxRetries = 8;
+            }).not.toThrow();
         });
 
         it("includes Authorization header when password is configured", async () => {
@@ -144,13 +213,15 @@ describe("WebhookService", () => {
                 .mockRejectedValueOnce(new Error("ECONNREFUSED"))
                 .mockRejectedValueOnce(new Error("ECONNREFUSED"));
 
-            // dispatch is async (awaits getWebhooks), but sendPost is fire-and-forget
+            // dispatch is async (awaits getWebhooks), but sendPost is fire-and-forget.
             await service.dispatch({ type: "test-event", data: {} });
 
-            // Wait for the fire-and-forget sendPost + catch chain to settle
-            await new Promise(resolve => setTimeout(resolve, 50));
-
-            expect(service.log.warn).toHaveBeenCalledWith(expect.stringContaining("Failed to dispatch"));
+            // Poll for the fire-and-forget catch chain to settle. vi.waitFor
+            // retries the assertion on a short interval until it passes or
+            // the default timeout fires — replaces a brittle fixed-50ms wait.
+            await vi.waitFor(() => {
+                expect(service.log.warn).toHaveBeenCalledWith(expect.stringContaining("Failed to dispatch"));
+            });
         });
     });
 });

--- a/packages/server/src/server/services/webhookService/index.ts
+++ b/packages/server/src/server/services/webhookService/index.ts
@@ -16,6 +16,14 @@ export class WebhookService extends Loggable {
     /** Base delay in ms for exponential backoff. Override in tests. */
     retryBaseDelayMs = 1000;
 
+    /**
+     * Maximum delivery attempts before giving up. Override in tests.
+     * 8 attempts spread over 1+2+4+8+16+32+64+128 ≈ 255s of backoff covers
+     * a typical openclaw gateway restart (15-30s) with ample margin.
+     * See bluebubbles-server#71.
+     */
+    maxRetries = 8;
+
     async dispatch(event: WebhookEvent) {
         const webhooks = await Server().repo.getWebhooks();
         for (const i of webhooks) {
@@ -41,7 +49,7 @@ export class WebhookService extends Loggable {
             headers["Authorization"] = `Bearer ${password}`;
         }
 
-        const maxRetries = 3;
+        const maxRetries = this.maxRetries;
         const baseDelayMs = this.retryBaseDelayMs;
 
         for (let attempt = 1; attempt <= maxRetries; attempt++) {

--- a/packages/server/src/server/services/webhookService/index.ts
+++ b/packages/server/src/server/services/webhookService/index.ts
@@ -20,9 +20,29 @@ export class WebhookService extends Loggable {
      * Maximum delivery attempts before giving up. Override in tests.
      * 8 attempts spread over 1+2+4+8+16+32+64+128 ≈ 255s of backoff covers
      * a typical openclaw gateway restart (15-30s) with ample margin.
+     * Hard-capped at 20 to bound `Math.pow(2, attempt - 1)` and avoid the
+     * `setTimeout` int32 overflow at ~24.8 days.
      * See bluebubbles-server#71.
      */
-    maxRetries = 8;
+    private _maxRetries = 8;
+    get maxRetries(): number {
+        return this._maxRetries;
+    }
+    set maxRetries(value: number) {
+        if (!Number.isInteger(value) || value < 1 || value > 20) {
+            throw new RangeError(`maxRetries must be an integer in [1, 20], got ${value}`);
+        }
+        this._maxRetries = value;
+    }
+
+    /**
+     * Jitter factor applied to each backoff delay. Default 0.2 means the
+     * computed delay is multiplied by a random factor in [1.0, 1.2). This
+     * desynchronizes recovery on bursty restart cascades — without it,
+     * dozens of in-flight retry chains fired at t=0 would all wake on the
+     * same exponential boundary and pile-drive the gateway. 0 disables.
+     */
+    retryJitterFactor = 0.2;
 
     async dispatch(event: WebhookEvent) {
         const webhooks = await Server().repo.getWebhooks();
@@ -51,20 +71,28 @@ export class WebhookService extends Loggable {
 
         const maxRetries = this.maxRetries;
         const baseDelayMs = this.retryBaseDelayMs;
+        const jitter = this.retryJitterFactor;
 
         for (let attempt = 1; attempt <= maxRetries; attempt++) {
             try {
                 return await axios.post(url, event, { headers });
             } catch (err) {
-                if (attempt < maxRetries) {
-                    const delay = baseDelayMs * Math.pow(2, attempt - 1);
-                    this.log.debug(
-                        `Webhook delivery failed (attempt ${attempt}/${maxRetries}), retrying in ${delay}ms: ${url}`
-                    );
-                    await new Promise(resolve => setTimeout(resolve, delay));
-                } else {
+                // 4xx (except 429) are permanent — retrying for 255s blocks
+                // the slot for a misconfigured webhook with no chance of
+                // success. 429 is rate-limit-style and SHOULD retry. The
+                // gateway-restart case (ECONNREFUSED / ETIMEDOUT / 5xx) has
+                // no err.response.status and falls through to retry.
+                const status = (err as { response?: { status?: number } })?.response?.status;
+                const isPermanent = typeof status === "number" && status >= 400 && status < 500 && status !== 429;
+                if (isPermanent || attempt >= maxRetries) {
                     throw err;
                 }
+                const baseDelay = baseDelayMs * Math.pow(2, attempt - 1);
+                const delay = jitter > 0 ? Math.floor(baseDelay * (1 + Math.random() * jitter)) : baseDelay;
+                this.log.debug(
+                    `Webhook delivery failed (attempt ${attempt}/${maxRetries}), retrying in ${delay}ms: ${url}`
+                );
+                await new Promise(resolve => setTimeout(resolve, delay));
             }
         }
     }


### PR DESCRIPTION
Closes #71.

Bumps `WebhookService.maxRetries` from 3 to 8. Exposes as a class field mirroring `retryBaseDelayMs` for testability.

## Why

Default 7s retry budget is shorter than openclaw gateway restart (15-30s). Result: every iMessage webhook dispatched during a deploy/restart is silently dropped — no DLQ, no recovery. Today's incident on canon: 11 deploys in 3 hours = 11 lossy windows; Nadia's messages to Colette went into the void.

## What

| Change | File | Lines |
|---|---|---|
| Add `maxRetries = 8` class field | `webhookService/index.ts` | +8 |
| Use `this.maxRetries` in `sendPost` | `webhookService/index.ts` | -1 / +1 |
| Pin `maxRetries=3` in test `beforeEach` | `webhookService.test.ts` | +6 |
| New: assert default value is 8 | `webhookService.test.ts` | +6 |
| New: assert success on attempt 8 | `webhookService.test.ts` | +13 |

8 attempts spread over 1+2+4+8+16+32+64+128 ≈ 255s clock time — covers any normal gateway restart with significant margin.

## What this is NOT

This is the cheap-and-cheerful half. The durable fix is gateway-side catchup-on-startup using BB-server's `GET /api/v1/message/query?after=<cursor>` endpoint — tracked at [openclaw-infra#1378](https://github.com/markthebest12/openclaw-infra/issues/1378). Once that lands and soaks for a week, this PR's bumped budget can be reverted to upstream defaults if Mark wants minimal fork divergence.

## Verification

```
cd packages/server && npx vitest run src/server/services/webhookService/__tests__/
# Test Files  1 passed (1)
#       Tests  8 passed (8)
```

## Cross-references

- Closes #71
- Companion: openclaw-infra#1378 (catchup-on-startup detector)
- Related: today's incident analysis in openclaw-infra session log